### PR TITLE
Add repo capability digest and MCP server catalog

### DIFF
--- a/docs/mcp/OVERVIEW.md
+++ b/docs/mcp/OVERVIEW.md
@@ -1,0 +1,28 @@
+# MCP Server Catalog Overview
+
+This catalog condenses the Docker MCP server listings into summaries for quick reference during agent orchestration. Each bullet links to the full upstream documentation captured in this repository.
+
+- [`Airtable MCP Server`](airtable-mcp-server.md) (13 tools) — Provides AI assistants with direct access to Airtable bases, allowing them to read schemas, query records, and interact with your Airtable data. Supports listing bases, retrieving table structures, and searching through records to help automate workflows and answer questions about your organized data.
+- [`Atlassian MCP Server`](atlassian.md) (37 tools) — Tools for Atlassian products (Confluence and Jira). This integration supports both Atlassian Cloud and Jira Server/Data Center deployments.
+- [`Couchbase MCP Server`](couchbase.md) (11 tools) — Couchbase is a distributed document database with a powerful search engine and in-built operational and analytical capabilities.
+- [`MCP Database Server`](database-server.md) — Comprehensive database server supporting PostgreSQL, MySQL, and SQLite with natural language SQL query capabilities. Enables AI agents to interact with databases through both direct SQL and natural language queries.
+- [`Docker Hub MCP Server`](dockerhub.md) (13 tools) — Docker Hub official MCP server.
+- [`DuckDuckGo MCP Server`](duckduckgo.md) (2 tools) — A Model Context Protocol (MCP) server that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing.
+- [`Elasticsearch MCP Server`](elasticsearch.md) (5 tools) — Interact with your Elasticsearch indices through natural language conversations.
+- [`Explorium B2B Data MCP Server`](explorium.md) (12 tools) — Discover companies, contacts, and business insights—powered by dozens of trusted external data sources.
+- [`Fetch (Reference) MCP Server`](fetch.md) (1 tool) — Fetches a URL from the internet and extracts its contents as markdown.
+- [`Git (Reference) MCP Server`](git.md) (12 tools) — Git repository interaction and automation.
+- [`GitHub Official MCP Server`](github-official.md) (96 tools) — Official GitHub MCP Server, by GitHub. Provides seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
+- [`Gmail MCP Server`](gmail-mcp.md) (3 tools) — A Model Context Protocol server for Gmail operations using IMAP/SMTP with app password authentication. Supports listing messages, searching emails, and sending messages.
+- [`Google Maps Comprehensive MCP Server`](google-maps-comprehensive.md) (8 tools) — Complete Google Maps integration with 8 tools including geocoding, places search, directions, elevation data, and more using Google's latest APIs.
+- [`Grafana MCP Server`](grafana.md) (45 tools) — MCP server for Grafana.
+- [`Heroku MCP Server`](heroku.md) (34 tools) — Heroku Platform MCP Server using the Heroku CLI.
+- [`Maestro MCP Server`](maestro-mcp-server.md) (35 tools) — A Model Context Protocol (MCP) server exposing Bitcoin blockchain data through the Maestro API platform. Provides tools to explore blocks, transactions, addresses, inscriptions, runes, and other metaprotocol data.
+- [`Mcp reddit MCP Server`](mcp-reddit.md) (6 tools) — A comprehensive Model Context Protocol (MCP) server for Reddit integration. This server enables AI agents to interact with Reddit programmatically through a standardized interface.
+- [`MongoDB MCP Server`](mongodb.md) (21 tools) — A Model Context Protocol server to connect to MongoDB databases and MongoDB Atlas Clusters.
+- [`Neon MCP Server`](neon.md) (19 tools) — MCP server for interacting with Neon Management API and databases.
+- [`Notion MCP Server`](notion.md) (19 tools) — Official Notion MCP Server.
+- [`Puppeteer (Archived) MCP Server`](puppeteer.md) (7 tools) — Browser automation and web scraping using Puppeteer.
+- [`Blazing-fast, asynchronous MCP server for seamless filesystem operations. MCP Server`](rust-mcp-filesystem.md) (24 tools) — The Rust MCP Filesystem is a high-performance, asynchronous, and lightweight Model Context Protocol (MCP) server built in Rust for secure and efficient filesystem operations. Designed with security in mind, it operates in read-only mode by default and restricts clients from updating allowed directories via MCP Roots unless explicitly enabled, ensuring robust protection against unauthorized access. Leveraging asynchronous I/O, it delivers blazingly fast performance with a minimal resource footprint.
+- [`SimpleCheckList MCP Server`](simplechecklist.md) (20 tools) — Advanced SimpleCheckList with MCP server and SQLite database for comprehensive task management.
+- [`Stripe MCP Server`](stripe.md) (22 tools) — Interact with Stripe services over the Stripe API.

--- a/docs/mcp/airtable-mcp-server.md
+++ b/docs/mcp/airtable-mcp-server.md
@@ -1,0 +1,184 @@
+# Airtable MCP Server MCP Server
+
+Provides AI assistants with direct access to Airtable bases, allowing them to read schemas, query records, and interact with your Airtable data. Supports listing bases, retrieving table structures, and searching through records to help automate workflows and answer questions about your organized data.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/airtable-mcp-server](https://hub.docker.com/repository/docker/mcp/airtable-mcp-server)
+**Author**|[domdomegg](https://github.com/domdomegg)
+**Repository**|https://github.com/domdomegg/airtable-mcp-server
+**Dockerfile**|https://github.com/domdomegg/airtable-mcp-server/blob/master/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/airtable-mcp-server)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/airtable-mcp-server --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (13)
+Tools provided by this Server|Short Description
+-|-
+`create_field`|Create a new field in a table|
+`create_record`|Create a new record in a table|
+`create_table`|Create a new table in a base|
+`delete_records`|Delete records from a table|
+`describe_table`|Get detailed information about a specific table|
+`get_record`|Get a specific record by ID|
+`list_bases`|List all accessible Airtable bases|
+`list_records`|List records from a table|
+`list_tables`|List all tables in a specific base|
+`search_records`|Search for records containing specific text|
+`update_field`|Update a field's name or description|
+`update_records`|Update up to 10 records in a table|
+`update_table`|Update a table's name or description|
+
+---
+## Tools Details
+
+#### Tool: **`create_field`**
+Create a new field in a table
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`nested`|`object`|
+`tableId`|`string`|The ID or name of the table
+
+---
+#### Tool: **`create_record`**
+Create a new record in a table
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`fields`|`object`|The fields for the new record
+`tableId`|`string`|The ID or name of the table
+
+---
+#### Tool: **`create_table`**
+Create a new table in a base
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`fields`|`array`|Array of field definitions
+`name`|`string`|The name of the table
+`description`|`string` *optional*|Optional description for the table
+
+---
+#### Tool: **`delete_records`**
+Delete records from a table
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`recordIds`|`array`|Array of record IDs to delete
+`tableId`|`string`|The ID or name of the table
+
+---
+#### Tool: **`describe_table`**
+Get detailed information about a specific table
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`tableId`|`string`|The ID or name of the table
+`detailLevel`|`string` *optional*|Level of detail to return
+
+---
+#### Tool: **`get_record`**
+Get a specific record by ID
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`recordId`|`string`|The ID of the record
+`tableId`|`string`|The ID or name of the table
+
+---
+#### Tool: **`list_bases`**
+List all accessible Airtable bases
+#### Tool: **`list_records`**
+List records from a table
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`tableId`|`string`|The ID or name of the table
+`filterByFormula`|`string` *optional*|A formula used to filter records
+`maxRecords`|`number` *optional*|The maximum total number of records that will be returned
+`sort`|`array` *optional*|A list of sort objects that specifies how the records will be ordered
+`view`|`string` *optional*|The name or ID of a view in the table
+
+---
+#### Tool: **`list_tables`**
+List all tables in a specific base
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`detailLevel`|`string` *optional*|Level of detail to return
+
+---
+#### Tool: **`search_records`**
+Search for records containing specific text
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`searchTerm`|`string`|The text to search for
+`tableId`|`string`|The ID or name of the table
+`fieldIds`|`array` *optional*|Optional array of field IDs to search in
+`maxRecords`|`number` *optional*|The maximum total number of records that will be returned
+`view`|`string` *optional*|The name or ID of a view in the table
+
+---
+#### Tool: **`update_field`**
+Update a field's name or description
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`fieldId`|`string`|The ID of the field
+`tableId`|`string`|The ID or name of the table
+`description`|`string` *optional*|New description for the field
+`name`|`string` *optional*|New name for the field
+
+---
+#### Tool: **`update_records`**
+Update up to 10 records in a table
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`records`|`array`|Array of records to update (max 10)
+`tableId`|`string`|The ID or name of the table
+
+---
+#### Tool: **`update_table`**
+Update a table's name or description
+Parameters|Type|Description
+-|-|-
+`baseId`|`string`|The ID of the base
+`tableId`|`string`|The ID or name of the table
+`description`|`string` *optional*|New description for the table
+`name`|`string` *optional*|New name for the table
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "airtable-mcp-server": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "NODE_ENV",
+        "-e",
+        "AIRTABLE_API_KEY",
+        "mcp/airtable-mcp-server"
+      ],
+      "env": {
+        "NODE_ENV": "production",
+        "AIRTABLE_API_KEY": "patABC123.def456ghi789jkl012mno345pqr678stu901vwx"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/atlassian.md
+++ b/docs/mcp/atlassian.md
@@ -1,0 +1,490 @@
+# Atlassian MCP Server
+
+Tools for Atlassian products (Confluence and Jira). This integration supports both Atlassian Cloud and Jira Server/Data Center deployments.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/atlassian](https://hub.docker.com/repository/docker/mcp/atlassian)
+**Author**|[sooperset](https://github.com/sooperset)
+**Repository**|https://github.com/sooperset/mcp-atlassian
+**Dockerfile**|https://github.com/sooperset/mcp-atlassian/blob/v0.11.2/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/atlassian)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/atlassian --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (37)
+Tools provided by this Server|Short Description
+-|-
+`confluence_add_comment`|Add a comment to a Confluence page.|
+`confluence_add_label`|Add label to an existing Confluence page.|
+`confluence_create_page`|Create a new Confluence page.|
+`confluence_delete_page`|Delete an existing Confluence page.|
+`confluence_get_comments`|Get comments for a specific Confluence page.|
+`confluence_get_labels`|Get labels for a specific Confluence page.|
+`confluence_get_page`|Get content of a specific Confluence page by its ID, or by its title and space key.|
+`confluence_get_page_children`|Get child pages of a specific Confluence page.|
+`confluence_search`|Search Confluence content using simple terms or CQL.|
+`confluence_update_page`|Update an existing Confluence page.|
+`jira_add_comment`|Add a comment to a Jira issue.|
+`jira_add_worklog`|Add a worklog entry to a Jira issue.|
+`jira_batch_create_issues`|Create multiple Jira issues in a batch.|
+`jira_batch_get_changelogs`|Get changelogs for multiple Jira issues (Cloud only).|
+`jira_create_issue`|Create a new Jira issue with optional Epic link or parent for subtasks.|
+`jira_create_issue_link`|Create a link between two Jira issues.|
+`jira_create_sprint`|Create Jira sprint for a board.|
+`jira_delete_issue`|Delete an existing Jira issue.|
+`jira_download_attachments`|Download attachments from a Jira issue.|
+`jira_get_agile_boards`|Get jira agile boards by name, project key, or type.|
+`jira_get_board_issues`|Get all issues linked to a specific board filtered by JQL.|
+`jira_get_issue`|Get details of a specific Jira issue including its Epic links and relationship information.|
+`jira_get_link_types`|Get all available issue link types.|
+`jira_get_project_issues`|Get all issues for a specific Jira project.|
+`jira_get_project_versions`|Get all fix versions for a specific Jira project.|
+`jira_get_sprint_issues`|Get jira issues from sprint.|
+`jira_get_sprints_from_board`|Get jira sprints from board by state.|
+`jira_get_transitions`|Get available status transitions for a Jira issue.|
+`jira_get_user_profile`|Retrieve profile information for a specific Jira user.|
+`jira_get_worklog`|Get worklog entries for a Jira issue.|
+`jira_link_to_epic`|Link an existing issue to an epic.|
+`jira_remove_issue_link`|Remove a link between two Jira issues.|
+`jira_search`|Search Jira issues using JQL (Jira Query Language).|
+`jira_search_fields`|Search Jira fields by keyword with fuzzy match.|
+`jira_transition_issue`|Transition a Jira issue to a new status.|
+`jira_update_issue`|Update an existing Jira issue including changing status, adding Epic links, updating fields, etc.|
+`jira_update_sprint`|Update jira sprint.|
+
+---
+## Tools Details
+
+#### Tool: **`confluence_add_comment`**
+Add a comment to a Confluence page.
+Parameters|Type|Description
+-|-|-
+`content`|`string`|The comment content in Markdown format
+`page_id`|`string`|The ID of the page to add a comment to
+
+---
+#### Tool: **`confluence_add_label`**
+Add label to an existing Confluence page.
+Parameters|Type|Description
+-|-|-
+`name`|`string`|The name of the label
+`page_id`|`string`|The ID of the page to update
+
+---
+#### Tool: **`confluence_create_page`**
+Create a new Confluence page.
+Parameters|Type|Description
+-|-|-
+`content`|`string`|The content of the page in Markdown format. Supports headings, lists, tables, code blocks, and other Markdown syntax
+`space_key`|`string`|The key of the space to create the page in (usually a short uppercase code like 'DEV', 'TEAM', or 'DOC')
+`title`|`string`|The title of the page
+`parent_id`|`string` *optional*|(Optional) parent page ID. If provided, this page will be created as a child of the specified page
+
+---
+#### Tool: **`confluence_delete_page`**
+Delete an existing Confluence page.
+Parameters|Type|Description
+-|-|-
+`page_id`|`string`|The ID of the page to delete
+
+---
+#### Tool: **`confluence_get_comments`**
+Get comments for a specific Confluence page.
+Parameters|Type|Description
+-|-|-
+`page_id`|`string`|Confluence page ID (numeric ID, can be parsed from URL, e.g. from 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title' -> '123456789')
+
+---
+#### Tool: **`confluence_get_labels`**
+Get labels for a specific Confluence page.
+Parameters|Type|Description
+-|-|-
+`page_id`|`string`|Confluence page ID (numeric ID, can be parsed from URL, e.g. from 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title' -> '123456789')
+
+---
+#### Tool: **`confluence_get_page`**
+Get content of a specific Confluence page by its ID, or by its title and space key.
+Parameters|Type|Description
+-|-|-
+`convert_to_markdown`|`boolean` *optional*|Whether to convert page to markdown (true) or keep it in raw HTML format (false). Raw HTML can reveal macros (like dates) not visible in markdown, but CAUTION: using HTML significantly increases token usage in AI responses.
+`include_metadata`|`boolean` *optional*|Whether to include page metadata such as creation date, last update, version, and labels.
+`page_id`|`string` *optional*|Confluence page ID (numeric ID, can be found in the page URL). For example, in the URL 'https://example.atlassian.net/wiki/spaces/TEAM/pages/123456789/Page+Title', the page ID is '123456789'. Provide this OR both 'title' and 'space_key'. If page_id is provided, title and space_key will be ignored.
+`space_key`|`string` *optional*|The key of the Confluence space where the page resides (e.g., 'DEV', 'TEAM'). Required if using 'title'.
+`title`|`string` *optional*|The exact title of the Confluence page. Use this with 'space_key' if 'page_id' is not known.
+
+---
+#### Tool: **`confluence_get_page_children`**
+Get child pages of a specific Confluence page.
+Parameters|Type|Description
+-|-|-
+`parent_id`|`string`|The ID of the parent page whose children you want to retrieve
+`convert_to_markdown`|`boolean` *optional*|Whether to convert page content to markdown (true) or keep it in raw HTML format (false). Only relevant if include_content is true.
+`expand`|`string` *optional*|Fields to expand in the response (e.g., 'version', 'body.storage')
+`include_content`|`boolean` *optional*|Whether to include the page content in the response
+`limit`|`integer` *optional*|Maximum number of child pages to return (1-50)
+`start`|`integer` *optional*|Starting index for pagination (0-based)
+
+---
+#### Tool: **`confluence_search`**
+Search Confluence content using simple terms or CQL.
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Search query - can be either a simple text (e.g. 'project documentation') or a CQL query string. Simple queries use 'siteSearch' by default, to mimic the WebUI search, with an automatic fallback to 'text' search if not supported. Examples of CQL:
+- Basic search: 'type=page AND space=DEV'
+- Personal space search: 'space="~username"' (note: personal space keys starting with ~ must be quoted)
+- Search by title: 'title~"Meeting Notes"'
+- Use siteSearch: 'siteSearch ~ "important concept"'
+- Use text search: 'text ~ "important concept"'
+- Recent content: 'created >= "2023-01-01"'
+- Content with specific label: 'label=documentation'
+- Recently modified content: 'lastModified > startOfMonth("-1M")'
+- Content modified this year: 'creator = currentUser() AND lastModified > startOfYear()'
+- Content you contributed to recently: 'contributor = currentUser() AND lastModified > startOfWeek()'
+- Content watched by user: 'watcher = "user@domain.com" AND type = page'
+- Exact phrase in content: 'text ~ "\"Urgent Review Required\"" AND label = "pending-approval"'
+- Title wildcards: 'title ~ "Minutes*" AND (space = "HR" OR space = "Marketing")'
+Note: Special identifiers need proper quoting in CQL: personal space keys (e.g., "~username"), reserved words, numeric IDs, and identifiers with special characters.
+`limit`|`integer` *optional*|Maximum number of results (1-50)
+`spaces_filter`|`string` *optional*|(Optional) Comma-separated list of space keys to filter results by. Overrides the environment variable CONFLUENCE_SPACES_FILTER if provided.
+
+---
+#### Tool: **`confluence_update_page`**
+Update an existing Confluence page.
+Parameters|Type|Description
+-|-|-
+`content`|`string`|The new content of the page in Markdown format
+`page_id`|`string`|The ID of the page to update
+`title`|`string`|The new title of the page
+`is_minor_edit`|`boolean` *optional*|Whether this is a minor edit
+`parent_id`|`string` *optional*|Optional the new parent page ID
+`version_comment`|`string` *optional*|Optional comment for this version
+
+---
+#### Tool: **`jira_add_comment`**
+Add a comment to a Jira issue.
+Parameters|Type|Description
+-|-|-
+`comment`|`string`|Comment text in Markdown format
+`issue_key`|`string`|Jira issue key (e.g., 'PROJ-123')
+
+---
+#### Tool: **`jira_add_worklog`**
+Add a worklog entry to a Jira issue.
+Parameters|Type|Description
+-|-|-
+`issue_key`|`string`|Jira issue key (e.g., 'PROJ-123')
+`time_spent`|`string`|Time spent in Jira format. Examples: '1h 30m' (1 hour and 30 minutes), '1d' (1 day), '30m' (30 minutes), '4h' (4 hours)
+`comment`|`string` *optional*|(Optional) Comment for the worklog in Markdown format
+`original_estimate`|`string` *optional*|(Optional) New value for the original estimate
+`remaining_estimate`|`string` *optional*|(Optional) New value for the remaining estimate
+`started`|`string` *optional*|(Optional) Start time in ISO format. If not provided, the current time will be used. Example: '2023-08-01T12:00:00.000+0000'
+
+---
+#### Tool: **`jira_batch_create_issues`**
+Create multiple Jira issues in a batch.
+Parameters|Type|Description
+-|-|-
+`issues`|`string`|JSON array of issue objects. Each object should contain:
+- project_key (required): The project key (e.g., 'PROJ')
+- summary (required): Issue summary/title
+- issue_type (required): Type of issue (e.g., 'Task', 'Bug')
+- description (optional): Issue description
+- assignee (optional): Assignee username or email
+- components (optional): Array of component names
+Example: [
+  {"project_key": "PROJ", "summary": "Issue 1", "issue_type": "Task"},
+  {"project_key": "PROJ", "summary": "Issue 2", "issue_type": "Bug", "components": ["Frontend"]}
+]
+`validate_only`|`boolean` *optional*|If true, only validates the issues without creating them
+
+---
+#### Tool: **`jira_batch_get_changelogs`**
+Get changelogs for multiple Jira issues (Cloud only).
+Parameters|Type|Description
+-|-|-
+`issue_ids_or_keys`|`array`|List of Jira issue IDs or keys, e.g. ['PROJ-123', 'PROJ-124']
+`fields`|`array` *optional*|(Optional) Filter the changelogs by fields, e.g. ['status', 'assignee']. Default to [] for all fields.
+`limit`|`integer` *optional*|Maximum number of changelogs to return in result for each issue. Default to -1 for all changelogs. Notice that it only limits the results in the response, the function will still fetch all the data.
+
+---
+#### Tool: **`jira_create_issue`**
+Create a new Jira issue with optional Epic link or parent for subtasks.
+Parameters|Type|Description
+-|-|-
+`issue_type`|`string`|Issue type (e.g. 'Task', 'Bug', 'Story', 'Epic', 'Subtask'). The available types depend on your project configuration. For subtasks, use 'Subtask' (not 'Sub-task') and include parent in additional_fields.
+`project_key`|`string`|The JIRA project key (e.g. 'PROJ', 'DEV', 'SUPPORT'). This is the prefix of issue keys in your project. Never assume what it might be, always ask the user.
+`summary`|`string`|Summary/title of the issue
+`additional_fields`|`object` *optional*|(Optional) Dictionary of additional fields to set. Examples:
+- Set priority: {'priority': {'name': 'High'}}
+- Add labels: {'labels': ['frontend', 'urgent']}
+- Link to parent (for any issue type): {'parent': 'PROJ-123'}
+- Set Fix Version/s: {'fixVersions': [{'id': '10020'}]}
+- Custom fields: {'customfield_10010': 'value'}
+`assignee`|`string` *optional*|(Optional) Assignee's user identifier (string): Email, display name, or account ID (e.g., 'user@example.com', 'John Doe', 'accountid:...')
+`components`|`string` *optional*|(Optional) Comma-separated list of component names to assign (e.g., 'Frontend,API')
+`description`|`string` *optional*|Issue description
+
+---
+#### Tool: **`jira_create_issue_link`**
+Create a link between two Jira issues.
+Parameters|Type|Description
+-|-|-
+`inward_issue_key`|`string`|The key of the inward issue (e.g., 'PROJ-123')
+`link_type`|`string`|The type of link to create (e.g., 'Duplicate', 'Blocks', 'Relates to')
+`outward_issue_key`|`string`|The key of the outward issue (e.g., 'PROJ-456')
+`comment`|`string` *optional*|(Optional) Comment to add to the link
+`comment_visibility`|`object` *optional*|(Optional) Visibility settings for the comment (e.g., {'type': 'group', 'value': 'jira-users'})
+
+---
+#### Tool: **`jira_create_sprint`**
+Create Jira sprint for a board.
+Parameters|Type|Description
+-|-|-
+`board_id`|`string`|The id of board (e.g., '1000')
+`end_date`|`string`|End time for sprint (ISO 8601 format)
+`sprint_name`|`string`|Name of the sprint (e.g., 'Sprint 1')
+`start_date`|`string`|Start time for sprint (ISO 8601 format)
+`goal`|`string` *optional*|(Optional) Goal of the sprint
+
+---
+#### Tool: **`jira_delete_issue`**
+Delete an existing Jira issue.
+Parameters|Type|Description
+-|-|-
+`issue_key`|`string`|Jira issue key (e.g. PROJ-123)
+
+---
+#### Tool: **`jira_download_attachments`**
+Download attachments from a Jira issue.
+Parameters|Type|Description
+-|-|-
+`issue_key`|`string`|Jira issue key (e.g., 'PROJ-123')
+`target_dir`|`string`|Directory where attachments should be saved
+
+---
+#### Tool: **`jira_get_agile_boards`**
+Get jira agile boards by name, project key, or type.
+Parameters|Type|Description
+-|-|-
+`board_name`|`string` *optional*|(Optional) The name of board, support fuzzy search
+`board_type`|`string` *optional*|(Optional) The type of jira board (e.g., 'scrum', 'kanban')
+`limit`|`integer` *optional*|Maximum number of results (1-50)
+`project_key`|`string` *optional*|(Optional) Jira project key (e.g., 'PROJ-123')
+`start_at`|`integer` *optional*|Starting index for pagination (0-based)
+
+---
+#### Tool: **`jira_get_board_issues`**
+Get all issues linked to a specific board filtered by JQL.
+Parameters|Type|Description
+-|-|-
+`board_id`|`string`|The id of the board (e.g., '1001')
+`jql`|`string`|JQL query string (Jira Query Language). Examples:
+- Find Epics: "issuetype = Epic AND project = PROJ"
+- Find issues in Epic: "parent = PROJ-123"
+- Find by status: "status = 'In Progress' AND project = PROJ"
+- Find by assignee: "assignee = currentUser()"
+- Find recently updated: "updated >= -7d AND project = PROJ"
+- Find by label: "labels = frontend AND project = PROJ"
+- Find by priority: "priority = High AND project = PROJ"
+`expand`|`string` *optional*|Optional fields to expand in the response (e.g., 'changelog').
+`fields`|`string` *optional*|Comma-separated fields to return in the results. Use '*all' for all fields, or specify individual fields like 'summary,status,assignee,priority'
+`limit`|`integer` *optional*|Maximum number of results (1-50)
+`start_at`|`integer` *optional*|Starting index for pagination (0-based)
+
+---
+#### Tool: **`jira_get_issue`**
+Get details of a specific Jira issue including its Epic links and relationship information.
+Parameters|Type|Description
+-|-|-
+`issue_key`|`string`|Jira issue key (e.g., 'PROJ-123')
+`comment_limit`|`integer` *optional*|Maximum number of comments to include (0 or null for no comments)
+`expand`|`string` *optional*|(Optional) Fields to expand. Examples: 'renderedFields' (for rendered content), 'transitions' (for available status transitions), 'changelog' (for history)
+`fields`|`string` *optional*|(Optional) Comma-separated list of fields to return (e.g., 'summary,status,customfield_10010'). You may also provide a single field as a string (e.g., 'duedate'). Use '*all' for all fields (including custom fields), or omit for essential fields only.
+`properties`|`string` *optional*|(Optional) A comma-separated list of issue properties to return
+`update_history`|`boolean` *optional*|Whether to update the issue view history for the requesting user
+
+---
+#### Tool: **`jira_get_link_types`**
+Get all available issue link types.
+#### Tool: **`jira_get_project_issues`**
+Get all issues for a specific Jira project.
+Parameters|Type|Description
+-|-|-
+`project_key`|`string`|The project key
+`limit`|`integer` *optional*|Maximum number of results (1-50)
+`start_at`|`integer` *optional*|Starting index for pagination (0-based)
+
+---
+#### Tool: **`jira_get_project_versions`**
+Get all fix versions for a specific Jira project.
+Parameters|Type|Description
+-|-|-
+`project_key`|`string`|Jira project key (e.g., 'PROJ')
+
+---
+#### Tool: **`jira_get_sprint_issues`**
+Get jira issues from sprint.
+Parameters|Type|Description
+-|-|-
+`sprint_id`|`string`|The id of sprint (e.g., '10001')
+`fields`|`string` *optional*|Comma-separated fields to return in the results. Use '*all' for all fields, or specify individual fields like 'summary,status,assignee,priority'
+`limit`|`integer` *optional*|Maximum number of results (1-50)
+`start_at`|`integer` *optional*|Starting index for pagination (0-based)
+
+---
+#### Tool: **`jira_get_sprints_from_board`**
+Get jira sprints from board by state.
+Parameters|Type|Description
+-|-|-
+`board_id`|`string`|The id of board (e.g., '1000')
+`limit`|`integer` *optional*|Maximum number of results (1-50)
+`start_at`|`integer` *optional*|Starting index for pagination (0-based)
+`state`|`string` *optional*|Sprint state (e.g., 'active', 'future', 'closed')
+
+---
+#### Tool: **`jira_get_transitions`**
+Get available status transitions for a Jira issue.
+Parameters|Type|Description
+-|-|-
+`issue_key`|`string`|Jira issue key (e.g., 'PROJ-123')
+
+---
+#### Tool: **`jira_get_user_profile`**
+Retrieve profile information for a specific Jira user.
+Parameters|Type|Description
+-|-|-
+`user_identifier`|`string`|Identifier for the user (e.g., email address 'user@example.com', username 'johndoe', account ID 'accountid:...', or key for Server/DC).
+
+---
+#### Tool: **`jira_get_worklog`**
+Get worklog entries for a Jira issue.
+Parameters|Type|Description
+-|-|-
+`issue_key`|`string`|Jira issue key (e.g., 'PROJ-123')
+
+---
+#### Tool: **`jira_link_to_epic`**
+Link an existing issue to an epic.
+Parameters|Type|Description
+-|-|-
+`epic_key`|`string`|The key of the epic to link to (e.g., 'PROJ-456')
+`issue_key`|`string`|The key of the issue to link (e.g., 'PROJ-123')
+
+---
+#### Tool: **`jira_remove_issue_link`**
+Remove a link between two Jira issues.
+Parameters|Type|Description
+-|-|-
+`link_id`|`string`|The ID of the link to remove
+
+---
+#### Tool: **`jira_search`**
+Search Jira issues using JQL (Jira Query Language).
+Parameters|Type|Description
+-|-|-
+`jql`|`string`|JQL query string (Jira Query Language). Examples:
+- Find Epics: "issuetype = Epic AND project = PROJ"
+- Find issues in Epic: "parent = PROJ-123"
+- Find by status: "status = 'In Progress' AND project = PROJ"
+- Find by assignee: "assignee = currentUser()"
+- Find recently updated: "updated >= -7d AND project = PROJ"
+- Find by label: "labels = frontend AND project = PROJ"
+- Find by priority: "priority = High AND project = PROJ"
+`expand`|`string` *optional*|(Optional) fields to expand. Examples: 'renderedFields', 'transitions', 'changelog'
+`fields`|`string` *optional*|(Optional) Comma-separated fields to return in the results. Use '*all' for all fields, or specify individual fields like 'summary,status,assignee,priority'
+`limit`|`integer` *optional*|Maximum number of results (1-50)
+`projects_filter`|`string` *optional*|(Optional) Comma-separated list of project keys to filter results by. Overrides the environment variable JIRA_PROJECTS_FILTER if provided.
+`start_at`|`integer` *optional*|Starting index for pagination (0-based)
+
+---
+#### Tool: **`jira_search_fields`**
+Search Jira fields by keyword with fuzzy match.
+Parameters|Type|Description
+-|-|-
+`keyword`|`string` *optional*|Keyword for fuzzy search. If left empty, lists the first 'limit' available fields in their default order.
+`limit`|`integer` *optional*|Maximum number of results
+`refresh`|`boolean` *optional*|Whether to force refresh the field list
+
+---
+#### Tool: **`jira_transition_issue`**
+Transition a Jira issue to a new status.
+Parameters|Type|Description
+-|-|-
+`issue_key`|`string`|Jira issue key (e.g., 'PROJ-123')
+`transition_id`|`string`|ID of the transition to perform. Use the jira_get_transitions tool first to get the available transition IDs for the issue. Example values: '11', '21', '31'
+`comment`|`string` *optional*|(Optional) Comment to add during the transition. This will be visible in the issue history.
+`fields`|`object` *optional*|(Optional) Dictionary of fields to update during the transition. Some transitions require specific fields to be set (e.g., resolution). Example: {'resolution': {'name': 'Fixed'}}
+
+---
+#### Tool: **`jira_update_issue`**
+Update an existing Jira issue including changing status, adding Epic links, updating fields, etc.
+Parameters|Type|Description
+-|-|-
+`fields`|`object`|Dictionary of fields to update. For 'assignee', provide a string identifier (email, name, or accountId). Example: `{'assignee': 'user@example.com', 'summary': 'New Summary'}`
+`issue_key`|`string`|Jira issue key (e.g., 'PROJ-123')
+`additional_fields`|`object` *optional*|(Optional) Dictionary of additional fields to update. Use this for custom fields or more complex updates.
+`attachments`|`string` *optional*|(Optional) JSON string array or comma-separated list of file paths to attach to the issue. Example: '/path/to/file1.txt,/path/to/file2.txt' or ['/path/to/file1.txt','/path/to/file2.txt']
+
+---
+#### Tool: **`jira_update_sprint`**
+Update jira sprint.
+Parameters|Type|Description
+-|-|-
+`sprint_id`|`string`|The id of sprint (e.g., '10001')
+`end_date`|`string` *optional*|(Optional) New end date for the sprint
+`goal`|`string` *optional*|(Optional) New goal for the sprint
+`sprint_name`|`string` *optional*|(Optional) New name for the sprint
+`start_date`|`string` *optional*|(Optional) New start date for the sprint
+`state`|`string` *optional*|(Optional) New state for the sprint (future|active|closed)
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "atlassian": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "CONFLUENCE_URL",
+        "-e",
+        "CONFLUENCE_USERNAME",
+        "-e",
+        "JIRA_URL",
+        "-e",
+        "JIRA_USERNAME",
+        "-e",
+        "CONFLUENCE_API_TOKEN",
+        "-e",
+        "CONFLUENCE_PERSONAL_TOKEN",
+        "-e",
+        "JIRA_API_TOKEN",
+        "-e",
+        "JIRA_PERSONAL_TOKEN",
+        "mcp/atlassian"
+      ],
+      "env": {
+        "CONFLUENCE_URL": "https://your-company.atlassian.net/wiki",
+        "CONFLUENCE_USERNAME": "your.email@company.com",
+        "JIRA_URL": "https://your-company.atlassian.net",
+        "JIRA_USERNAME": "your.email@company.com",
+        "CONFLUENCE_API_TOKEN": "your_api_token",
+        "CONFLUENCE_PERSONAL_TOKEN": "your_api_token",
+        "JIRA_API_TOKEN": "your_api_token",
+        "JIRA_PERSONAL_TOKEN": "your_api_token"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/couchbase.md
+++ b/docs/mcp/couchbase.md
@@ -1,0 +1,163 @@
+# Couchbase MCP Server
+
+Couchbase is a distributed document database with a powerful search engine and in-built operational and analytical capabilities.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/couchbase](https://hub.docker.com/repository/docker/mcp/couchbase)
+**Author**|[Couchbase-Ecosystem](https://github.com/Couchbase-Ecosystem)
+**Repository**|https://github.com/Couchbase-Ecosystem/mcp-server-couchbase
+**Dockerfile**|https://github.com/Couchbase-Ecosystem/mcp-server-couchbase/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/couchbase)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/couchbase --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|Apache License 2.0
+
+## Available Tools (11)
+Tools provided by this Server|Short Description
+-|-
+`delete_document_by_id`|Delete a document by its ID.|
+`get_buckets_in_cluster`|Get the names of all the accessible buckets in the cluster.|
+`get_collections_in_scope`|Get the names of all collections in the given scope and bucket.|
+`get_document_by_id`|Get a document by its ID from the specified scope and collection.|
+`get_schema_for_collection`|Get the schema for a collection in the specified scope.|
+`get_scopes_and_collections_in_bucket`|Get the names of all scopes and collections in the bucket.|
+`get_scopes_in_bucket`|Get the names of all scopes in the given bucket.|
+`get_server_configuration_status`|Get the server status and configuration without establishing connection.|
+`run_sql_plus_plus_query`|Run a SQL++ query on a scope and return the results as a list of JSON objects.|
+`test_cluster_connection`|Test the connection to Couchbase cluster and optionally to a bucket.|
+`upsert_document_by_id`|Insert or update a document by its ID.|
+
+---
+## Tools Details
+
+#### Tool: **`delete_document_by_id`**
+Delete a document by its ID.
+    Returns True on success, False on failure.
+Parameters|Type|Description
+-|-|-
+`bucket_name`|`string`|
+`collection_name`|`string`|
+`document_id`|`string`|
+`scope_name`|`string`|
+
+---
+#### Tool: **`get_buckets_in_cluster`**
+Get the names of all the accessible buckets in the cluster.
+#### Tool: **`get_collections_in_scope`**
+Get the names of all collections in the given scope and bucket.
+Parameters|Type|Description
+-|-|-
+`bucket_name`|`string`|
+`scope_name`|`string`|
+
+---
+#### Tool: **`get_document_by_id`**
+Get a document by its ID from the specified scope and collection.
+    If the document is not found, it will raise an exception.
+Parameters|Type|Description
+-|-|-
+`bucket_name`|`string`|
+`collection_name`|`string`|
+`document_id`|`string`|
+`scope_name`|`string`|
+
+---
+#### Tool: **`get_schema_for_collection`**
+Get the schema for a collection in the specified scope.
+    Returns a dictionary with the collection name and the schema returned by running INFER query on the Couchbase collection.
+Parameters|Type|Description
+-|-|-
+`bucket_name`|`string`|
+`collection_name`|`string`|
+`scope_name`|`string`|
+
+---
+#### Tool: **`get_scopes_and_collections_in_bucket`**
+Get the names of all scopes and collections in the bucket.
+    Returns a dictionary with scope names as keys and lists of collection names as values.
+Parameters|Type|Description
+-|-|-
+`bucket_name`|`string`|
+
+---
+#### Tool: **`get_scopes_in_bucket`**
+Get the names of all scopes in the given bucket.
+Parameters|Type|Description
+-|-|-
+`bucket_name`|`string`|
+
+---
+#### Tool: **`get_server_configuration_status`**
+Get the server status and configuration without establishing connection.
+    This tool can be used to verify if the server is running and check the configuration.
+#### Tool: **`run_sql_plus_plus_query`**
+Run a SQL++ query on a scope and return the results as a list of JSON objects.
+Parameters|Type|Description
+-|-|-
+`bucket_name`|`string`|
+`query`|`string`|
+`scope_name`|`string`|
+
+---
+#### Tool: **`test_cluster_connection`**
+Test the connection to Couchbase cluster and optionally to a bucket.
+    This tool verifies the connection to the Couchbase cluster and bucket by establishing the connection if it is not already established.
+    If bucket name is not provided, it will not try to connect to the bucket specified in the MCP server settings.
+    Returns connection status and basic cluster information.
+Parameters|Type|Description
+-|-|-
+`bucket_name`|`string` *optional*|
+
+---
+#### Tool: **`upsert_document_by_id`**
+Insert or update a document by its ID.
+    Returns True on success, False on failure.
+Parameters|Type|Description
+-|-|-
+`bucket_name`|`string`|
+`collection_name`|`string`|
+`document_content`|`object`|
+`document_id`|`string`|
+`scope_name`|`string`|
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "couchbase": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "CB_CONNECTION_STRING",
+        "-e",
+        "CB_USERNAME",
+        "-e",
+        "CB_BUCKET_NAME",
+        "-e",
+        "CB_MCP_READ_ONLY_QUERY_MODE",
+        "-e",
+        "CB_PASSWORD",
+        "mcp/couchbase"
+      ],
+      "env": {
+        "CB_CONNECTION_STRING": "couchbases://cb.example.com",
+        "CB_USERNAME": "Administrator",
+        "CB_BUCKET_NAME": "my-bucket",
+        "CB_MCP_READ_ONLY_QUERY_MODE": "true",
+        "CB_PASSWORD": "<CB_PASSWORD>"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/database-server.md
+++ b/docs/mcp/database-server.md
@@ -1,0 +1,132 @@
+# MCP Database Server
+
+Comprehensive database server supporting PostgreSQL, MySQL, and SQLite with natural language SQL query capabilities. Enables AI agents to interact with databases through both direct SQL and natural language queries.
+
+## Features
+
+- **Multi-Database Support**: Works with SQLite, PostgreSQL, and MySQL
+- **Natural Language Queries**: Convert natural language to SQL automatically
+- **Direct SQL Execution**: Execute raw SQL with safety checks
+- **Schema Inspection**: List tables and describe table structures
+- **FastAPI Web Interface**: RESTful API endpoints for web integration
+- **Docker Ready**: Fully containerized with health checks
+
+## Available MCP Tools
+
+### `query_database`
+**Description**: Execute natural language queries against the database and convert them to SQL
+
+**Usage**: Ask questions like "Show me all users created in the last week" or "Find the top 10 products by sales"
+
+**Arguments**:
+- `query` (string): Natural language description of what you want to query from the database
+
+### `list_tables`
+**Description**: List all available tables in the current database
+
+**Usage**: Ask "What tables are available?" or "Show me the database structure"
+
+### `describe_table`
+**Description**: Get detailed schema information for a specific table including columns, types, and constraints
+
+**Usage**: Ask "Describe the users table" or "What columns does the products table have?"
+
+**Arguments**:
+- `table_name` (string): Name of the table to describe
+
+### `execute_sql`
+**Description**: Execute raw SQL queries with safety checks and validation
+
+**Usage**: Execute specific SQL commands when you need precise control
+
+**Arguments**:
+- `query` (string): SQL query to execute
+
+### `connect_to_database`
+**Description**: Connect to a new database using provided connection details
+
+**Usage**: Switch between different databases during your session
+
+**Arguments**:
+- `connection_string` (string): Database connection string
+
+### `get_connection_examples`
+**Description**: Get example connection strings for different database types (SQLite, PostgreSQL, MySQL)
+
+**Usage**: Ask "How do I connect to a PostgreSQL database?" or "Show me connection examples"
+
+### `get_current_database_info`
+**Description**: Get information about the currently connected database including type, version, and connection status
+
+**Usage**: Ask "What database am I connected to?" or "Show me current connection details"
+
+## Example Queries
+
+Here are some example questions you can ask your agent:
+
+```python
+# Basic queries
+"Show me all users in the database"
+"What tables are available?"
+"Describe the products table structure"
+
+# Complex analysis
+"Find the top 5 customers by total order value"
+"Show me users who registered in the last month"
+"What's the average product price by category?"
+
+# Data exploration
+"How many orders were placed yesterday?"
+"List all products that are out of stock"
+"Find duplicate email addresses in the users table"
+```
+
+## Configuration
+
+The server requires a `DATABASE_URL` environment variable with your database connection string:
+
+### SQLite (recommended for testing)
+```
+DATABASE_URL=sqlite+aiosqlite:///data/mydb.db
+```
+
+### PostgreSQL
+```
+DATABASE_URL=postgresql+asyncpg://user:password@localhost:5432/mydb
+```
+
+### MySQL
+```
+DATABASE_URL=mysql+aiomysql://user:password@localhost:3306/mydb
+```
+
+## Docker Usage
+
+```bash
+# Run with SQLite (simplest setup)
+docker run -d \
+  -p 3000:3000 \
+  -e DATABASE_URL=sqlite+aiosqlite:///data/mydb.db \
+  souhardyak/mcp-db-server
+
+# Run with PostgreSQL
+docker run -d \
+  -p 3000:3000 \
+  -e DATABASE_URL=postgresql+asyncpg://user:password@host:5432/db \
+  souhardyak/mcp-db-server
+
+# Run with persistent SQLite storage
+docker run -d \
+  -p 3000:3000 \
+  -v /host/data:/data \
+  -e DATABASE_URL=sqlite+aiosqlite:///data/mydb.db \
+  souhardyak/mcp-db-server
+```
+
+## Health Check
+
+The server provides a health endpoint at `/health` that returns database connectivity status.
+
+## Source Code
+
+Full source code and documentation available at: https://github.com/Souhar-dya/mcp-db-server

--- a/docs/mcp/dockerhub.md
+++ b/docs/mcp/dockerhub.md
@@ -1,0 +1,184 @@
+# Docker Hub MCP Server
+
+Docker Hub official MCP server.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/dockerhub](https://hub.docker.com/repository/docker/mcp/dockerhub)
+**Author**|[docker](https://github.com/docker)
+**Repository**|https://github.com/docker/hub-mcp
+**Dockerfile**|https://github.com/docker/hub-mcp/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/dockerhub)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/dockerhub --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|Apache License 2.0
+
+## Available Tools (13)
+Tools provided by this Server|Short Description
+-|-
+`checkRepository`|Check Repository Exists|
+`checkRepositoryTag`|Check Repository Tag|
+`createRepository`|Create Repository in namespace|
+`dockerHardenedImages`|List available Docker Hardened Images|
+`getPersonalNamespace`|Get Personal Namespace|
+`getRepositoryInfo`|Get Repository Info|
+`getRepositoryTag`|Get Repository Tag|
+`listAllNamespacesMemberOf`|List All Namespaces user is a member of|
+`listNamespaces`|List Namespaces|
+`listRepositoriesByNamespace`|List Repositories by Namespace|
+`listRepositoryTags`|List Repository Tags|
+`search`|Search Repositories|
+`updateRepositoryInfo`|Get Repository Info|
+
+---
+## Tools Details
+
+#### Tool: **`checkRepository`**
+Check if a repository exists in the given namespace.
+Parameters|Type|Description
+-|-|-
+`namespace`|`string`|
+`repository`|`string`|
+
+---
+#### Tool: **`checkRepositoryTag`**
+Check if a tag exists in a repository
+Parameters|Type|Description
+-|-|-
+`namespace`|`string`|
+`repository`|`string`|
+`tag`|`string`|
+
+---
+#### Tool: **`createRepository`**
+Create a new repository in the given namespace. You MUST ask the user for the repository name and if the repository has to be public or private. Can optionally pass a description.
+IMPORTANT: Before calling this tool, you must ensure you have:
+ The repository name (name).
+Parameters|Type|Description
+-|-|-
+`namespace`|`string`|The namespace of the repository. Required.
+`description`|`string` *optional*|The description of the repository
+`full_description`|`string` *optional*|A detailed description of the repository
+`is_private`|`boolean` *optional*|Whether the repository is private
+`name`|`string` *optional*|The name of the repository (required). Must contain a combination of alphanumeric characters and may contain the special characters ., _, or -. Letters must be lowercase.
+`registry`|`string` *optional*|The registry to create the repository in
+
+---
+#### Tool: **`dockerHardenedImages`**
+This API is used to list Docker Hardened Images (DHIs) available in the user organisations. The tool takes the organisation name as input and returns the list of DHI images available in the organisation. It depends on the "listNamespaces" tool to be called first to get the list of organisations the user has access to.
+Parameters|Type|Description
+-|-|-
+`organisation`|`string`|The organisation for which the DHIs are listed for. If user does not explicitly ask for a specific organisation, the "listNamespaces" tool should be called first to get the list of organisations the user has access to.
+
+---
+#### Tool: **`getPersonalNamespace`**
+Get the personal namespace name
+#### Tool: **`getRepositoryInfo`**
+Get the details of a repository in the given namespace.
+Parameters|Type|Description
+-|-|-
+`namespace`|`string`|The namespace of the repository (required). If not provided the `library` namespace will be used for official images.
+`repository`|`string`|The repository name (required)
+
+---
+#### Tool: **`getRepositoryTag`**
+Get the details of a tag in a repository. It can be use to show the latest tag details for example.
+Parameters|Type|Description
+-|-|-
+`namespace`|`string`|
+`repository`|`string`|
+`tag`|`string`|
+
+---
+#### Tool: **`listAllNamespacesMemberOf`**
+List all namespaces the user is a member of
+#### Tool: **`listNamespaces`**
+List paginated namespaces
+Parameters|Type|Description
+-|-|-
+`page`|`number` *optional*|The page number to list repositories from
+`page_size`|`number` *optional*|The page size to list repositories from
+
+---
+#### Tool: **`listRepositoriesByNamespace`**
+List paginated repositories by namespace
+Parameters|Type|Description
+-|-|-
+`namespace`|`string`|The namespace to list repositories from
+`content_types`|`string` *optional*|Comma-delimited list of content types. Only repositories containing one or more artifacts with one of these content types will be returned. Default is empty to get all repositories.
+`media_types`|`string` *optional*|Comma-delimited list of media types. Only repositories containing one or more artifacts with one of these media types will be returned. Default is empty to get all repositories.
+`ordering`|`string` *optional*|The ordering of the repositories. Use "-" to reverse the ordering. For example, "last_updated" will order the repositories by last updated in descending order while "-last_updated" will order the repositories by last updated in ascending order.
+`page`|`number` *optional*|The page number to list repositories from
+`page_size`|`number` *optional*|The page size to list repositories from
+
+---
+#### Tool: **`listRepositoryTags`**
+List paginated tags by repository
+Parameters|Type|Description
+-|-|-
+`repository`|`string`|The repository to list tags from
+`architecture`|`string` *optional*|The architecture to list tags from. If not provided, all architectures will be listed.
+`namespace`|`string` *optional*|The namespace of the repository. If not provided the 'library' namespace will be used for official images.
+`os`|`string` *optional*|The operating system to list tags from. If not provided, all operating systems will be listed.
+`page`|`number` *optional*|The page number to list tags from
+`page_size`|`number` *optional*|The page size to list tags from
+
+---
+#### Tool: **`search`**
+Search for repositories in Docker Hub. It sorts results by best match if no sort criteria is provided. If user asks for secure, production-ready images the "dockerHardenedImages" tool should be called first to get the list of DHI images available in the user organisations (if any) and fallback to search tool if no DHI images are available or user is not authenticated.
+Parameters|Type|Description
+-|-|-
+`query`|`string`|The query to search for
+`architectures`|`array` *optional*|The architectures to filter search results
+`badges`|`array` *optional*|The trusted content to search for
+`categories`|`array` *optional*|The categories names to filter search results
+`extension_reviewed`|`boolean` *optional*|Whether to filter search results to only include reviewed extensions
+`from`|`number` *optional*|The number of repositories to skip
+`images`|`array` *optional*|The images to filter search results
+`operating_systems`|`array` *optional*|The operating systems to filter search results
+`order`|`string` *optional*|The order to sort the search results by
+`size`|`number` *optional*|The number of repositories to return
+`sort`|`string` *optional*|The criteria to sort the search results by. If the `sort` field is not set, the best match is used by default. When search extensions, documents are sort alphabetically if none is provided. Do not use it unless user explicitly asks for it.
+`type`|`string` *optional*|The type of the repository to search for
+
+---
+#### Tool: **`updateRepositoryInfo`**
+Update the details of a repository in the given namespace. Description, overview and status are the only fields that can be updated. While description and overview changes are fine, a status change is a dangerous operation so the user must explicitly ask for it.
+Parameters|Type|Description
+-|-|-
+`namespace`|`string`|The namespace of the repository (required)
+`repository`|`string`|The repository name (required)
+`description`|`string` *optional*|The description of the repository. If user asks for updating the description of the repository, this is the field that should be updated.
+`full_description`|`string` *optional*|The full description (overview)of the repository. If user asks for updating the full description or the overview of the repository, this is the field that should be updated. 
+`status`|`string` *optional*|The status of the repository. If user asks for updating the status of the repository, this is the field that should be updated. This is a dangerous operation and should be done with caution so user must be prompted to confirm the operation. Valid status are `active` (1) and `inactive` (0). Normally do not update the status if it is not strictly required by the user. It is not possible to change an `inactive` repository to `active` if it has no images.
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "dockerhub": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "HUB_PAT_TOKEN",
+        "mcp/dockerhub",
+        "--transport=stdio",
+        "--username={{dockerhub.username}}"
+      ],
+      "env": {
+        "HUB_PAT_TOKEN": "your_hub_pat_token"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/duckduckgo.md
+++ b/docs/mcp/duckduckgo.md
@@ -1,0 +1,61 @@
+# DuckDuckGo MCP Server
+
+A Model Context Protocol (MCP) server that provides web search capabilities through DuckDuckGo, with additional features for content fetching and parsing.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/duckduckgo](https://hub.docker.com/repository/docker/mcp/duckduckgo)
+**Author**|[nickclyde](https://github.com/nickclyde)
+**Repository**|https://github.com/nickclyde/duckduckgo-mcp-server
+**Dockerfile**|https://github.com/nickclyde/duckduckgo-mcp-server/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/duckduckgo)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/duckduckgo --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (2)
+Tools provided by this Server|Short Description
+-|-
+`fetch_content`|Fetch and parse content from a webpage URL.|
+`search`|Search DuckDuckGo and return formatted results.|
+
+---
+## Tools Details
+
+#### Tool: **`fetch_content`**
+Fetch and parse content from a webpage URL.
+Parameters|Type|Description
+-|-|-
+`url`|`string`|The webpage URL to fetch content from
+
+---
+#### Tool: **`search`**
+Search DuckDuckGo and return formatted results.
+Parameters|Type|Description
+-|-|-
+`query`|`string`|The search query string
+`max_results`|`integer` *optional*|Maximum number of results to return (default: 10)
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "duckduckgo": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/duckduckgo"
+      ]
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/elasticsearch.md
+++ b/docs/mcp/elasticsearch.md
@@ -1,0 +1,105 @@
+# Elasticsearch MCP Server
+
+Interact with your Elasticsearch indices through natural language conversations.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/elasticsearch](https://hub.docker.com/repository/docker/mcp/elasticsearch)
+**Author**|[elastic](https://github.com/elastic)
+**Repository**|https://github.com/elastic/mcp-server-elasticsearch
+**Dockerfile**|https://github.com/elastic/mcp-server-elasticsearch/blob/v0.4.0/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/elasticsearch)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/elasticsearch --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|Apache License 2.0
+
+## Available Tools (5)
+Tools provided by this Server|Short Description
+-|-
+`esql`|Elasticsearch ES|QL query|
+`get_mappings`|Get ES index mappings|
+`get_shards`|Get ES shard information|
+`list_indices`|List ES indices|
+`search`|Elasticsearch search DSL query|
+
+---
+## Tools Details
+
+#### Tool: **`esql`**
+Perform an Elasticsearch ES|QL query.
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Complete Elasticsearch ES|QL query
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_mappings`**
+Get field mappings for a specific Elasticsearch index
+Parameters|Type|Description
+-|-|-
+`index`|`string`|Name of the Elasticsearch index to get mappings for
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_shards`**
+Get shard information for all or specific indices.
+Parameters|Type|Description
+-|-|-
+`index`|`string` *optional*|Optional index name to get shard information for
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_indices`**
+List all available Elasticsearch indices
+Parameters|Type|Description
+-|-|-
+`index_pattern`|`string`|Index pattern of Elasticsearch indices to list
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`search`**
+Perform an Elasticsearch search with the provided query DSL.
+Parameters|Type|Description
+-|-|-
+`index`|`string`|Name of the Elasticsearch index to search
+`query_body`|`object`|Complete Elasticsearch query DSL object that can include query, size, from, sort, etc.
+`fields`|`array` *optional*|Name of the fields that need to be returned (optional)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "elasticsearch": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "ES_URL",
+        "-e",
+        "ES_API_KEY",
+        "mcp/elasticsearch",
+        "stdio"
+      ],
+      "env": {
+        "ES_URL": "http://localhost:9200",
+        "ES_API_KEY": "your-api-key"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/explorium.md
+++ b/docs/mcp/explorium.md
@@ -1,0 +1,85 @@
+# Explorium B2B Data MCP Server
+
+Discover companies, contacts, and business insights—powered by dozens of trusted external data sources.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/explorium](https://hub.docker.com/repository/docker/mcp/explorium)
+**Author**|[explorium-ai](https://github.com/explorium-ai)
+**Repository**|https://github.com/explorium-ai/mcp-explorium
+**Dockerfile**|https://github.com/explorium-ai/mcp-explorium/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/explorium)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/explorium --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (12)
+Tools provided by this Server|Short Description
+-|-
+`match-business`|Get the Explorium business IDs from business name and/or domain in bulk|
+`fetch-businesses`|Fetch businesses from the Explorium API using filter criteria|
+`fetch-businesses-statistics`|Fetch aggregated insights into businesses by industry, revenue, employee count, and geographic distribution|
+`fetch-businesses-events`|Retrieves business-related events from the Explorium API in bulk|
+`enrich-business`|Enriches business data using up to 5 parallel enrichment calls|
+`match-prospects`|Match specific individuals to get their Explorium prospect IDs|
+`fetch-prospects`|Fetch prospects (employees) from the Explorium API using detailed filter criteria|
+`fetch-prospects-events`|Retrieves prospect-related events from the Explorium API in bulk|
+`fetch-prospects-statistics`|Fetch aggregated insights into prospects by job department and geographic distribution|
+`enrich-prospects`|Enriches prospect data using up to 3 parallel enrichment calls|
+`autocomplete`|Autocomplete values for business filters based on a query|
+`web-search`|Perform web search using Explorium Search capabilities|
+
+---
+## Tools Details
+
+#### Tool: **`match-business`**
+Get the Explorium business IDs from business name and/or domain in bulk
+#### Tool: **`fetch-businesses`**
+Fetch businesses from the Explorium API using filter criteria
+#### Tool: **`fetch-businesses-statistics`**
+Fetch aggregated insights into businesses by industry, revenue, employee count, and geographic distribution
+#### Tool: **`fetch-businesses-events`**
+Retrieves business-related events from the Explorium API in bulk
+#### Tool: **`enrich-business`**
+Enriches business data using up to 5 parallel enrichment calls
+#### Tool: **`match-prospects`**
+Match specific individuals to get their Explorium prospect IDs
+#### Tool: **`fetch-prospects`**
+Fetch prospects (employees) from the Explorium API using detailed filter criteria
+#### Tool: **`fetch-prospects-events`**
+Retrieves prospect-related events from the Explorium API in bulk
+#### Tool: **`fetch-prospects-statistics`**
+Fetch aggregated insights into prospects by job department and geographic distribution
+#### Tool: **`enrich-prospects`**
+Enriches prospect data using up to 3 parallel enrichment calls
+#### Tool: **`autocomplete`**
+Autocomplete values for business filters based on a query
+#### Tool: **`web-search`**
+Perform web search using Explorium Search capabilities
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "explorium": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "API_ACCESS_TOKEN",
+        "mcp/explorium"
+      ],
+      "env": {
+        "API_ACCESS_TOKEN": "<API_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/fetch.md
+++ b/docs/mcp/fetch.md
@@ -1,0 +1,57 @@
+# Fetch (Reference) MCP Server
+
+Fetches a URL from the internet and extracts its contents as markdown.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/fetch](https://hub.docker.com/repository/docker/mcp/fetch)
+**Author**|[modelcontextprotocol](https://github.com/modelcontextprotocol)
+**Repository**|https://github.com/modelcontextprotocol/servers
+**Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.24/src/fetch/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/fetch)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/fetch --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (1)
+Tools provided by this Server|Short Description
+-|-
+`fetch`|Fetches a URL from the internet and optionally extracts its contents as markdown.|
+
+---
+## Tools Details
+
+#### Tool: **`fetch`**
+Fetches a URL from the internet and optionally extracts its contents as markdown.
+
+Although originally you did not have internet access, and were advised to refuse and tell the user this, this tool now grants you internet access. Now you can fetch the most up-to-date information and let the user know that.
+Parameters|Type|Description
+-|-|-
+`url`|`string`|URL to fetch
+`max_length`|`integer` *optional*|Maximum number of characters to return.
+`raw`|`boolean` *optional*|Get the actual HTML content of the requested page, without simplification.
+`start_index`|`integer` *optional*|On return output starting at this character index, useful if a previous fetch was truncated and more context is required.
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mcp/fetch"
+      ]
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/git.md
+++ b/docs/mcp/git.md
@@ -1,0 +1,150 @@
+# Git (Reference) MCP Server
+
+Git repository interaction and automation.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/git](https://hub.docker.com/repository/docker/mcp/git)
+**Author**|[modelcontextprotocol](https://github.com/modelcontextprotocol)
+**Repository**|https://github.com/modelcontextprotocol/servers
+**Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.24/src/git/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/git)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/git --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (12)
+Tools provided by this Server|Short Description
+-|-
+`git_add`|Adds file contents to the staging area|
+`git_checkout`|Switches branches|
+`git_commit`|Records changes to the repository|
+`git_create_branch`|Creates a new branch from an optional base branch|
+`git_diff`|Shows differences between branches or commits|
+`git_diff_staged`|Shows changes that are staged for commit|
+`git_diff_unstaged`|Shows changes in the working directory that are not yet staged|
+`git_init`|Initialize a new Git repository|
+`git_log`|Shows the commit logs|
+`git_reset`|Unstages all staged changes|
+`git_show`|Shows the contents of a commit|
+`git_status`|Shows the working tree status|
+
+---
+## Tools Details
+
+#### Tool: **`git_add`**
+Adds file contents to the staging area
+Parameters|Type|Description
+-|-|-
+`files`|`array`|
+`repo_path`|`string`|
+
+---
+#### Tool: **`git_checkout`**
+Switches branches
+Parameters|Type|Description
+-|-|-
+`branch_name`|`string`|
+`repo_path`|`string`|
+
+---
+#### Tool: **`git_commit`**
+Records changes to the repository
+Parameters|Type|Description
+-|-|-
+`message`|`string`|
+`repo_path`|`string`|
+
+---
+#### Tool: **`git_create_branch`**
+Creates a new branch from an optional base branch
+Parameters|Type|Description
+-|-|-
+`branch_name`|`string`|
+`repo_path`|`string`|
+`base_branch`|`string` *optional*|
+
+---
+#### Tool: **`git_diff`**
+Shows differences between branches or commits
+Parameters|Type|Description
+-|-|-
+`repo_path`|`string`|
+`target`|`string`|
+
+---
+#### Tool: **`git_diff_staged`**
+Shows changes that are staged for commit
+Parameters|Type|Description
+-|-|-
+`repo_path`|`string`|
+
+---
+#### Tool: **`git_diff_unstaged`**
+Shows changes in the working directory that are not yet staged
+Parameters|Type|Description
+-|-|-
+`repo_path`|`string`|
+
+---
+#### Tool: **`git_init`**
+Initialize a new Git repository
+Parameters|Type|Description
+-|-|-
+`repo_path`|`string`|
+
+---
+#### Tool: **`git_log`**
+Shows the commit logs
+Parameters|Type|Description
+-|-|-
+`repo_path`|`string`|
+`max_count`|`integer` *optional*|
+
+---
+#### Tool: **`git_reset`**
+Unstages all staged changes
+Parameters|Type|Description
+-|-|-
+`repo_path`|`string`|
+
+---
+#### Tool: **`git_show`**
+Shows the contents of a commit
+Parameters|Type|Description
+-|-|-
+`repo_path`|`string`|
+`revision`|`string`|
+
+---
+#### Tool: **`git_status`**
+Shows the working tree status
+Parameters|Type|Description
+-|-|-
+`repo_path`|`string`|
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "git": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-v",
+        "/local-directory:/local-directory",
+        "mcp/git"
+      ]
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/github-official.md
+++ b/docs/mcp/github-official.md
@@ -1,0 +1,1273 @@
+# GitHub Official MCP Server
+
+Official GitHub MCP Server, by GitHub. Provides seamless integration with GitHub APIs, enabling advanced automation and interaction capabilities for developers and tools.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[ghcr.io/github/github-mcp-server](https://hub.docker.com/repository/docker/ghcr.io/github/github-mcp-server)
+**Author**|[github](https://github.com/github)
+**Repository**|https://github.com/github/github-mcp-server
+**Dockerfile**|https://github.com/github/github-mcp-server/blob/main/Dockerfile
+**Docker Image built by**|github
+**Docker Scout Health Score**|Not available
+**Verify Signature**|Not available
+**Licence**|MIT License
+
+## Available Tools (96)
+Tools provided by this Server|Short Description
+-|-
+`add_comment_to_pending_review`|Add review comment to the requester's latest pending pull request review|
+`add_issue_comment`|Add comment to issue|
+`add_sub_issue`|Add sub-issue|
+`assign_copilot_to_issue`|Assign Copilot to issue|
+`cancel_workflow_run`|Cancel workflow run|
+`create_and_submit_pull_request_review`|Create and submit a pull request review without comments|
+`create_branch`|Create branch|
+`create_gist`|Create Gist|
+`create_issue`|Open new issue|
+`create_or_update_file`|Create or update file|
+`create_pending_pull_request_review`|Create pending pull request review|
+`create_pull_request`|Open new pull request|
+`create_repository`|Create repository|
+`delete_file`|Delete file|
+`delete_pending_pull_request_review`|Delete the requester's latest pending pull request review|
+`delete_workflow_run_logs`|Delete workflow logs|
+`dismiss_notification`|Dismiss notification|
+`download_workflow_run_artifact`|Download workflow artifact|
+`fork_repository`|Fork repository|
+`get_code_scanning_alert`|Get code scanning alert|
+`get_commit`|Get commit details|
+`get_dependabot_alert`|Get dependabot alert|
+`get_discussion`|Get discussion|
+`get_discussion_comments`|Get discussion comments|
+`get_file_contents`|Get file or directory contents|
+`get_global_security_advisory`|Get a global security advisory|
+`get_issue`|Get issue details|
+`get_issue_comments`|Get issue comments|
+`get_job_logs`|Get job logs|
+`get_latest_release`|Get latest release|
+`get_me`|Get my user profile|
+`get_notification_details`|Get notification details|
+`get_project`|Get project|
+`get_pull_request`|Get pull request details|
+`get_pull_request_diff`|Get pull request diff|
+`get_pull_request_files`|Get pull request files|
+`get_pull_request_review_comments`|Get pull request review comments|
+`get_pull_request_reviews`|Get pull request reviews|
+`get_pull_request_status`|Get pull request status checks|
+`get_release_by_tag`|Get a release by tag name|
+`get_secret_scanning_alert`|Get secret scanning alert|
+`get_tag`|Get tag details|
+`get_team_members`|Get team members|
+`get_teams`|Get teams|
+`get_workflow_run`|Get workflow run|
+`get_workflow_run_logs`|Get workflow run logs|
+`get_workflow_run_usage`|Get workflow usage|
+`list_branches`|List branches|
+`list_code_scanning_alerts`|List code scanning alerts|
+`list_commits`|List commits|
+`list_dependabot_alerts`|List dependabot alerts|
+`list_discussion_categories`|List discussion categories|
+`list_discussions`|List discussions|
+`list_gists`|List Gists|
+`list_global_security_advisories`|List global security advisories|
+`list_issue_types`|List available issue types|
+`list_issues`|List issues|
+`list_notifications`|List notifications|
+`list_org_repository_security_advisories`|List org repository security advisories|
+`list_project_fields`|List project fields|
+`list_projects`|List projects|
+`list_pull_requests`|List pull requests|
+`list_releases`|List releases|
+`list_repository_security_advisories`|List repository security advisories|
+`list_secret_scanning_alerts`|List secret scanning alerts|
+`list_starred_repositories`|List starred repositories|
+`list_sub_issues`|List sub-issues|
+`list_tags`|List tags|
+`list_workflow_jobs`|List workflow jobs|
+`list_workflow_run_artifacts`|List workflow artifacts|
+`list_workflow_runs`|List workflow runs|
+`list_workflows`|List workflows|
+`manage_notification_subscription`|Manage notification subscription|
+`manage_repository_notification_subscription`|Manage repository notification subscription|
+`mark_all_notifications_read`|Mark all notifications as read|
+`merge_pull_request`|Merge pull request|
+`push_files`|Push files to repository|
+`remove_sub_issue`|Remove sub-issue|
+`reprioritize_sub_issue`|Reprioritize sub-issue|
+`request_copilot_review`|Request Copilot review|
+`rerun_failed_jobs`|Rerun failed jobs|
+`rerun_workflow_run`|Rerun workflow run|
+`run_workflow`|Run workflow|
+`search_code`|Search code|
+`search_issues`|Search issues|
+`search_orgs`|Search organizations|
+`search_pull_requests`|Search pull requests|
+`search_repositories`|Search repositories|
+`search_users`|Search users|
+`star_repository`|Star repository|
+`submit_pending_pull_request_review`|Submit the requester's latest pending pull request review|
+`unstar_repository`|Unstar repository|
+`update_gist`|Update Gist|
+`update_issue`|Edit issue|
+`update_pull_request`|Edit pull request|
+`update_pull_request_branch`|Update pull request branch|
+
+---
+## Tools Details
+
+#### Tool: **`add_comment_to_pending_review`**
+Add review comment to the requester's latest pending pull request review. A pending review needs to already exist to call this (check with the user if not sure).
+Parameters|Type|Description
+-|-|-
+`body`|`string`|The text of the review comment
+`owner`|`string`|Repository owner
+`path`|`string`|The relative path to the file that necessitates a comment
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+`subjectType`|`string`|The level at which the comment is targeted
+`line`|`number` *optional*|The line of the blob in the pull request diff that the comment applies to. For multi-line comments, the last line of the range
+`side`|`string` *optional*|The side of the diff to comment on. LEFT indicates the previous state, RIGHT indicates the new state
+`startLine`|`number` *optional*|For multi-line comments, the first line of the range that the comment applies to
+`startSide`|`string` *optional*|For multi-line comments, the starting side of the diff that the comment applies to. LEFT indicates the previous state, RIGHT indicates the new state
+
+---
+#### Tool: **`add_issue_comment`**
+Add a comment to a specific issue in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`body`|`string`|Comment content
+`issue_number`|`number`|Issue number to comment on
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+
+---
+#### Tool: **`add_sub_issue`**
+Add a sub-issue to a parent issue in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`issue_number`|`number`|The number of the parent issue
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`sub_issue_id`|`number`|The ID of the sub-issue to add. ID is not the same as issue number
+`replace_parent`|`boolean` *optional*|When true, replaces the sub-issue's current parent issue
+
+---
+#### Tool: **`assign_copilot_to_issue`**
+Assign Copilot to a specific issue in a GitHub repository.
+
+This tool can help with the following outcomes:
+- a Pull Request created with source code changes to resolve the issue
+
+
+More information can be found at:
+- https://docs.github.com/en/copilot/using-github-copilot/using-copilot-coding-agent-to-work-on-tasks/about-assigning-tasks-to-copilot
+Parameters|Type|Description
+-|-|-
+`issueNumber`|`number`|Issue number
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+
+---
+#### Tool: **`cancel_workflow_run`**
+Cancel a workflow run
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`run_id`|`number`|The unique identifier of the workflow run
+
+---
+#### Tool: **`create_and_submit_pull_request_review`**
+Create and submit a review for a pull request without review comments.
+Parameters|Type|Description
+-|-|-
+`body`|`string`|Review comment text
+`event`|`string`|Review action to perform
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+`commitID`|`string` *optional*|SHA of commit to review
+
+---
+#### Tool: **`create_branch`**
+Create a new branch in a GitHub repository
+Parameters|Type|Description
+-|-|-
+`branch`|`string`|Name for new branch
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`from_branch`|`string` *optional*|Source branch (defaults to repo default)
+
+---
+#### Tool: **`create_gist`**
+Create a new gist
+Parameters|Type|Description
+-|-|-
+`content`|`string`|Content for simple single-file gist creation
+`filename`|`string`|Filename for simple single-file gist creation
+`description`|`string` *optional*|Description of the gist
+`public`|`boolean` *optional*|Whether the gist is public
+
+---
+#### Tool: **`create_issue`**
+Create a new issue in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`title`|`string`|Issue title
+`assignees`|`array` *optional*|Usernames to assign to this issue
+`body`|`string` *optional*|Issue body content
+`labels`|`array` *optional*|Labels to apply to this issue
+`milestone`|`number` *optional*|Milestone number
+`type`|`string` *optional*|Type of this issue
+
+---
+#### Tool: **`create_or_update_file`**
+Create or update a single file in a GitHub repository. If updating, you must provide the SHA of the file you want to update. Use this tool to create or update a file in a GitHub repository remotely; do not use it for local file operations.
+Parameters|Type|Description
+-|-|-
+`branch`|`string`|Branch to create/update the file in
+`content`|`string`|Content of the file
+`message`|`string`|Commit message
+`owner`|`string`|Repository owner (username or organization)
+`path`|`string`|Path where to create/update the file
+`repo`|`string`|Repository name
+`sha`|`string` *optional*|Required if updating an existing file. The blob SHA of the file being replaced.
+
+---
+#### Tool: **`create_pending_pull_request_review`**
+Create a pending review for a pull request. Call this first before attempting to add comments to a pending review, and ultimately submitting it. A pending pull request review means a pull request review, it is pending because you create it first and submit it later, and the PR author will not see it until it is submitted.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+`commitID`|`string` *optional*|SHA of commit to review
+
+---
+#### Tool: **`create_pull_request`**
+Create a new pull request in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`base`|`string`|Branch to merge into
+`head`|`string`|Branch containing changes
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`title`|`string`|PR title
+`body`|`string` *optional*|PR description
+`draft`|`boolean` *optional*|Create as draft PR
+`maintainer_can_modify`|`boolean` *optional*|Allow maintainer edits
+
+---
+#### Tool: **`create_repository`**
+Create a new GitHub repository in your account or specified organization
+Parameters|Type|Description
+-|-|-
+`name`|`string`|Repository name
+`autoInit`|`boolean` *optional*|Initialize with README
+`description`|`string` *optional*|Repository description
+`organization`|`string` *optional*|Organization to create the repository in (omit to create in your personal account)
+`private`|`boolean` *optional*|Whether repo should be private
+
+---
+#### Tool: **`delete_file`**
+Delete a file from a GitHub repository
+Parameters|Type|Description
+-|-|-
+`branch`|`string`|Branch to delete the file from
+`message`|`string`|Commit message
+`owner`|`string`|Repository owner (username or organization)
+`path`|`string`|Path to the file to delete
+`repo`|`string`|Repository name
+
+*This tool may perform destructive updates.*
+
+---
+#### Tool: **`delete_pending_pull_request_review`**
+Delete the requester's latest pending pull request review. Use this after the user decides not to submit a pending review, if you don't know if they already created one then check first.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+
+---
+#### Tool: **`delete_workflow_run_logs`**
+Delete logs for a workflow run
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`run_id`|`number`|The unique identifier of the workflow run
+
+*This tool may perform destructive updates.*
+
+---
+#### Tool: **`dismiss_notification`**
+Dismiss a notification by marking it as read or done
+Parameters|Type|Description
+-|-|-
+`threadID`|`string`|The ID of the notification thread
+`state`|`string` *optional*|The new state of the notification (read/done)
+
+---
+#### Tool: **`download_workflow_run_artifact`**
+Get download URL for a workflow run artifact
+Parameters|Type|Description
+-|-|-
+`artifact_id`|`number`|The unique identifier of the artifact
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`fork_repository`**
+Fork a GitHub repository to your account or specified organization
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`organization`|`string` *optional*|Organization to fork to
+
+---
+#### Tool: **`get_code_scanning_alert`**
+Get details of a specific code scanning alert in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`alertNumber`|`number`|The number of the alert.
+`owner`|`string`|The owner of the repository.
+`repo`|`string`|The name of the repository.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_commit`**
+Get details for a commit from a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`sha`|`string`|Commit SHA, branch name, or tag name
+`include_diff`|`boolean` *optional*|Whether to include file diffs and stats in the response. Default is true.
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_dependabot_alert`**
+Get details of a specific dependabot alert in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`alertNumber`|`number`|The number of the alert.
+`owner`|`string`|The owner of the repository.
+`repo`|`string`|The name of the repository.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_discussion`**
+Get a specific discussion by ID
+Parameters|Type|Description
+-|-|-
+`discussionNumber`|`number`|Discussion Number
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_discussion_comments`**
+Get comments from a discussion
+Parameters|Type|Description
+-|-|-
+`discussionNumber`|`number`|Discussion Number
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`after`|`string` *optional*|Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_file_contents`**
+Get the contents of a file or directory from a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner (username or organization)
+`repo`|`string`|Repository name
+`path`|`string` *optional*|Path to file/directory (directories must end with a slash '/')
+`ref`|`string` *optional*|Accepts optional git refs such as `refs/tags/{tag}`, `refs/heads/{branch}` or `refs/pull/{pr_number}/head`
+`sha`|`string` *optional*|Accepts optional commit SHA. If specified, it will be used instead of ref
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_global_security_advisory`**
+Get a global security advisory
+Parameters|Type|Description
+-|-|-
+`ghsaId`|`string`|GitHub Security Advisory ID (format: GHSA-xxxx-xxxx-xxxx).
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_issue`**
+Get details of a specific issue in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`issue_number`|`number`|The number of the issue
+`owner`|`string`|The owner of the repository
+`repo`|`string`|The name of the repository
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_issue_comments`**
+Get comments for a specific issue in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`issue_number`|`number`|Issue number
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_job_logs`**
+Download logs for a specific workflow job or efficiently get all failed job logs for a workflow run
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`failed_only`|`boolean` *optional*|When true, gets logs for all failed jobs in run_id
+`job_id`|`number` *optional*|The unique identifier of the workflow job (required for single job logs)
+`return_content`|`boolean` *optional*|Returns actual log content instead of URLs
+`run_id`|`number` *optional*|Workflow run ID (required when using failed_only)
+`tail_lines`|`number` *optional*|Number of lines to return from the end of the log
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_latest_release`**
+Get the latest release in a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_me`**
+Get details of the authenticated GitHub user. Use this when a request is about the user's own profile for GitHub. Or when information is missing to build other tool calls.
+#### Tool: **`get_notification_details`**
+Get detailed information for a specific GitHub notification, always call this tool when the user asks for details about a specific notification, if you don't know the ID list notifications first.
+Parameters|Type|Description
+-|-|-
+`notificationID`|`string`|The ID of the notification
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_project`**
+Get Project for a user or org
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive.
+`owner_type`|`string`|Owner type
+`project_number`|`number`|The project's number
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_pull_request`**
+Get details of a specific pull request in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_pull_request_diff`**
+Get the diff of a pull request.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_pull_request_files`**
+Get the files changed in a specific pull request.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_pull_request_review_comments`**
+Get pull request review comments. They are comments made on a portion of the unified diff during a pull request review. These are different from commit comments and issue comments in a pull request.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_pull_request_reviews`**
+Get reviews for a specific pull request.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_pull_request_status`**
+Get the status of a specific pull request.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_release_by_tag`**
+Get a specific release by its tag name in a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`tag`|`string`|Tag name (e.g., 'v1.0.0')
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_secret_scanning_alert`**
+Get details of a specific secret scanning alert in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`alertNumber`|`number`|The number of the alert.
+`owner`|`string`|The owner of the repository.
+`repo`|`string`|The name of the repository.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_tag`**
+Get details about a specific git tag in a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`tag`|`string`|Tag name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_team_members`**
+Get member usernames of a specific team in an organization. Limited to organizations accessible with current credentials
+Parameters|Type|Description
+-|-|-
+`org`|`string`|Organization login (owner) that contains the team.
+`team_slug`|`string`|Team slug
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_teams`**
+Get details of the teams the user is a member of. Limited to organizations accessible with current credentials
+Parameters|Type|Description
+-|-|-
+`user`|`string` *optional*|Username to get teams for. If not provided, uses the authenticated user.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_workflow_run`**
+Get details of a specific workflow run
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`run_id`|`number`|The unique identifier of the workflow run
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_workflow_run_logs`**
+Download logs for a specific workflow run (EXPENSIVE: downloads ALL logs as ZIP. Consider using get_job_logs with failed_only=true for debugging failed jobs)
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`run_id`|`number`|The unique identifier of the workflow run
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_workflow_run_usage`**
+Get usage metrics for a workflow run
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`run_id`|`number`|The unique identifier of the workflow run
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_branches`**
+List branches in a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_code_scanning_alerts`**
+List code scanning alerts in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|The owner of the repository.
+`repo`|`string`|The name of the repository.
+`ref`|`string` *optional*|The Git reference for the results you want to list.
+`severity`|`string` *optional*|Filter code scanning alerts by severity
+`state`|`string` *optional*|Filter code scanning alerts by state. Defaults to open
+`tool_name`|`string` *optional*|The name of the tool used for code scanning.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_commits`**
+Get list of commits of a branch in a GitHub repository. Returns at least 30 results per page by default, but can return more if specified using the perPage parameter (up to 100).
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`author`|`string` *optional*|Author username or email address to filter commits by
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`sha`|`string` *optional*|Commit SHA, branch or tag name to list commits of. If not provided, uses the default branch of the repository. If a commit SHA is provided, will list commits up to that SHA.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_dependabot_alerts`**
+List dependabot alerts in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|The owner of the repository.
+`repo`|`string`|The name of the repository.
+`severity`|`string` *optional*|Filter dependabot alerts by severity
+`state`|`string` *optional*|Filter dependabot alerts by state. Defaults to open
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_discussion_categories`**
+List discussion categories with their id and name, for a repository or organisation.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string` *optional*|Repository name. If not provided, discussion categories will be queried at the organisation level.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_discussions`**
+List discussions for a repository or organisation.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`after`|`string` *optional*|Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.
+`category`|`string` *optional*|Optional filter by discussion category ID. If provided, only discussions with this category are listed.
+`direction`|`string` *optional*|Order direction.
+`orderBy`|`string` *optional*|Order discussions by field. If provided, the 'direction' also needs to be provided.
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`repo`|`string` *optional*|Repository name. If not provided, discussions will be queried at the organisation level.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_gists`**
+List gists for a user
+Parameters|Type|Description
+-|-|-
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`since`|`string` *optional*|Only gists updated after this time (ISO 8601 timestamp)
+`username`|`string` *optional*|GitHub username (omit for authenticated user's gists)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_global_security_advisories`**
+List global security advisories from GitHub.
+Parameters|Type|Description
+-|-|-
+`affects`|`string` *optional*|Filter advisories by affected package or version (e.g. "package1,package2@1.0.0").
+`cveId`|`string` *optional*|Filter by CVE ID.
+`cwes`|`array` *optional*|Filter by Common Weakness Enumeration IDs (e.g. ["79", "284", "22"]).
+`ecosystem`|`string` *optional*|Filter by package ecosystem.
+`ghsaId`|`string` *optional*|Filter by GitHub Security Advisory ID (format: GHSA-xxxx-xxxx-xxxx).
+`isWithdrawn`|`boolean` *optional*|Whether to only return withdrawn advisories.
+`modified`|`string` *optional*|Filter by publish or update date or date range (ISO 8601 date or range).
+`published`|`string` *optional*|Filter by publish date or date range (ISO 8601 date or range).
+`severity`|`string` *optional*|Filter by severity.
+`type`|`string` *optional*|Advisory type.
+`updated`|`string` *optional*|Filter by update date or date range (ISO 8601 date or range).
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_issue_types`**
+List supported issue types for repository owner (organization).
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|The organization owner of the repository
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_issues`**
+List issues in a GitHub repository. For pagination, use the 'endCursor' from the previous response's 'pageInfo' in the 'after' parameter.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`after`|`string` *optional*|Cursor for pagination. Use the endCursor from the previous page's PageInfo for GraphQL APIs.
+`direction`|`string` *optional*|Order direction. If provided, the 'orderBy' also needs to be provided.
+`labels`|`array` *optional*|Filter by labels
+`orderBy`|`string` *optional*|Order issues by field. If provided, the 'direction' also needs to be provided.
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`since`|`string` *optional*|Filter by date (ISO 8601 timestamp)
+`state`|`string` *optional*|Filter by state, by default both open and closed issues are returned when not provided
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_notifications`**
+Lists all GitHub notifications for the authenticated user, including unread notifications, mentions, review requests, assignments, and updates on issues or pull requests. Use this tool whenever the user asks what to work on next, requests a summary of their GitHub activity, wants to see pending reviews, or needs to check for new updates or tasks. This tool is the primary way to discover actionable items, reminders, and outstanding work on GitHub. Always call this tool when asked what to work on next, what is pending, or what needs attention in GitHub.
+Parameters|Type|Description
+-|-|-
+`before`|`string` *optional*|Only show notifications updated before the given time (ISO 8601 format)
+`filter`|`string` *optional*|Filter notifications to, use default unless specified. Read notifications are ones that have already been acknowledged by the user. Participating notifications are those that the user is directly involved in, such as issues or pull requests they have commented on or created.
+`owner`|`string` *optional*|Optional repository owner. If provided with repo, only notifications for this repository are listed.
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`repo`|`string` *optional*|Optional repository name. If provided with owner, only notifications for this repository are listed.
+`since`|`string` *optional*|Only show notifications updated after the given time (ISO 8601 format)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_org_repository_security_advisories`**
+List repository security advisories for a GitHub organization.
+Parameters|Type|Description
+-|-|-
+`org`|`string`|The organization login.
+`direction`|`string` *optional*|Sort direction.
+`sort`|`string` *optional*|Sort field.
+`state`|`string` *optional*|Filter by advisory state.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_project_fields`**
+List Project fields for a user or org
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive.
+`owner_type`|`string`|Owner type
+`projectNumber`|`string`|The project's number.
+`per_page`|`number` *optional*|Number of results per page (max 100, default: 30)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_projects`**
+List Projects for a user or org
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|If owner_type == user it is the handle for the GitHub user account. If owner_type == org it is the name of the organization. The name is not case sensitive.
+`owner_type`|`string`|Owner type
+`per_page`|`number` *optional*|Number of results per page (max 100, default: 30)
+`query`|`string` *optional*|Filter projects by a search query (matches title and description)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_pull_requests`**
+List pull requests in a GitHub repository. If the user specifies an author, then DO NOT use this tool and use the search_pull_requests tool instead.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`base`|`string` *optional*|Filter by base branch
+`direction`|`string` *optional*|Sort direction
+`head`|`string` *optional*|Filter by head user/org and branch
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`sort`|`string` *optional*|Sort by
+`state`|`string` *optional*|Filter by state
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_releases`**
+List releases in a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_repository_security_advisories`**
+List repository security advisories for a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|The owner of the repository.
+`repo`|`string`|The name of the repository.
+`direction`|`string` *optional*|Sort direction.
+`sort`|`string` *optional*|Sort field.
+`state`|`string` *optional*|Filter by advisory state.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_secret_scanning_alerts`**
+List secret scanning alerts in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|The owner of the repository.
+`repo`|`string`|The name of the repository.
+`resolution`|`string` *optional*|Filter by resolution
+`secret_type`|`string` *optional*|A comma-separated list of secret types to return. All default secret patterns are returned. To return generic patterns, pass the token name(s) in the parameter.
+`state`|`string` *optional*|Filter by state
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_starred_repositories`**
+List starred repositories
+Parameters|Type|Description
+-|-|-
+`direction`|`string` *optional*|The direction to sort the results by.
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`sort`|`string` *optional*|How to sort the results. Can be either 'created' (when the repository was starred) or 'updated' (when the repository was last pushed to).
+`username`|`string` *optional*|Username to list starred repositories for. Defaults to the authenticated user.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_sub_issues`**
+List sub-issues for a specific issue in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`issue_number`|`number`|Issue number
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`page`|`number` *optional*|Page number for pagination (default: 1)
+`per_page`|`number` *optional*|Number of results per page (max 100, default: 30)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_tags`**
+List git tags in a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_workflow_jobs`**
+List jobs for a specific workflow run
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`run_id`|`number`|The unique identifier of the workflow run
+`filter`|`string` *optional*|Filters jobs by their completed_at timestamp
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_workflow_run_artifacts`**
+List artifacts for a workflow run
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`run_id`|`number`|The unique identifier of the workflow run
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_workflow_runs`**
+List workflow runs for a specific workflow
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`workflow_id`|`string`|The workflow ID or workflow file name
+`actor`|`string` *optional*|Returns someone's workflow runs. Use the login for the user who created the workflow run.
+`branch`|`string` *optional*|Returns workflow runs associated with a branch. Use the name of the branch.
+`event`|`string` *optional*|Returns workflow runs for a specific event type
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`status`|`string` *optional*|Returns workflow runs with the check run status
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_workflows`**
+List workflows in a repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`manage_notification_subscription`**
+Manage a notification subscription: ignore, watch, or delete a notification thread subscription.
+Parameters|Type|Description
+-|-|-
+`action`|`string`|Action to perform: ignore, watch, or delete the notification subscription.
+`notificationID`|`string`|The ID of the notification thread.
+
+---
+#### Tool: **`manage_repository_notification_subscription`**
+Manage a repository notification subscription: ignore, watch, or delete repository notifications subscription for the provided repository.
+Parameters|Type|Description
+-|-|-
+`action`|`string`|Action to perform: ignore, watch, or delete the repository notification subscription.
+`owner`|`string`|The account owner of the repository.
+`repo`|`string`|The name of the repository.
+
+---
+#### Tool: **`mark_all_notifications_read`**
+Mark all notifications as read
+Parameters|Type|Description
+-|-|-
+`lastReadAt`|`string` *optional*|Describes the last point that notifications were checked (optional). Default: Now
+`owner`|`string` *optional*|Optional repository owner. If provided with repo, only notifications for this repository are marked as read.
+`repo`|`string` *optional*|Optional repository name. If provided with owner, only notifications for this repository are marked as read.
+
+---
+#### Tool: **`merge_pull_request`**
+Merge a pull request in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+`commit_message`|`string` *optional*|Extra detail for merge commit
+`commit_title`|`string` *optional*|Title for merge commit
+`merge_method`|`string` *optional*|Merge method
+
+---
+#### Tool: **`push_files`**
+Push multiple files to a GitHub repository in a single commit
+Parameters|Type|Description
+-|-|-
+`branch`|`string`|Branch to push to
+`files`|`array`|Array of file objects to push, each object with path (string) and content (string)
+`message`|`string`|Commit message
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+
+---
+#### Tool: **`remove_sub_issue`**
+Remove a sub-issue from a parent issue in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`issue_number`|`number`|The number of the parent issue
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`sub_issue_id`|`number`|The ID of the sub-issue to remove. ID is not the same as issue number
+
+---
+#### Tool: **`reprioritize_sub_issue`**
+Reprioritize a sub-issue to a different position in the parent issue's sub-issue list.
+Parameters|Type|Description
+-|-|-
+`issue_number`|`number`|The number of the parent issue
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`sub_issue_id`|`number`|The ID of the sub-issue to reprioritize. ID is not the same as issue number
+`after_id`|`number` *optional*|The ID of the sub-issue to be prioritized after (either after_id OR before_id should be specified)
+`before_id`|`number` *optional*|The ID of the sub-issue to be prioritized before (either after_id OR before_id should be specified)
+
+---
+#### Tool: **`request_copilot_review`**
+Request a GitHub Copilot code review for a pull request. Use this for automated feedback on pull requests, usually before requesting a human reviewer.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+
+---
+#### Tool: **`rerun_failed_jobs`**
+Re-run only the failed jobs in a workflow run
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`run_id`|`number`|The unique identifier of the workflow run
+
+---
+#### Tool: **`rerun_workflow_run`**
+Re-run an entire workflow run
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`run_id`|`number`|The unique identifier of the workflow run
+
+---
+#### Tool: **`run_workflow`**
+Run an Actions workflow by workflow ID or filename
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`ref`|`string`|The git reference for the workflow. The reference can be a branch or tag name.
+`repo`|`string`|Repository name
+`workflow_id`|`string`|The workflow ID (numeric) or workflow file name (e.g., main.yml, ci.yaml)
+`inputs`|`object` *optional*|Inputs the workflow accepts
+
+---
+#### Tool: **`search_code`**
+Fast and precise code search across ALL GitHub repositories using GitHub's native search engine. Best for finding exact symbols, functions, classes, or specific code patterns.
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Search query using GitHub's powerful code search syntax. Examples: 'content:Skill language:Java org:github', 'NOT is:archived language:Python OR language:go', 'repo:github/github-mcp-server'. Supports exact matching, language filters, path filters, and more.
+`order`|`string` *optional*|Sort order for results
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`sort`|`string` *optional*|Sort field ('indexed' only)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`search_issues`**
+Search for issues in GitHub repositories using issues search syntax already scoped to is:issue
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Search query using GitHub issues search syntax
+`order`|`string` *optional*|Sort order
+`owner`|`string` *optional*|Optional repository owner. If provided with repo, only issues for this repository are listed.
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`repo`|`string` *optional*|Optional repository name. If provided with owner, only issues for this repository are listed.
+`sort`|`string` *optional*|Sort field by number of matches of categories, defaults to best match
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`search_orgs`**
+Find GitHub organizations by name, location, or other organization metadata. Ideal for discovering companies, open source foundations, or teams.
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Organization search query. Examples: 'microsoft', 'location:california', 'created:>=2025-01-01'. Search is automatically scoped to type:org.
+`order`|`string` *optional*|Sort order
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`sort`|`string` *optional*|Sort field by category
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`search_pull_requests`**
+Search for pull requests in GitHub repositories using issues search syntax already scoped to is:pr
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Search query using GitHub pull request search syntax
+`order`|`string` *optional*|Sort order
+`owner`|`string` *optional*|Optional repository owner. If provided with repo, only pull requests for this repository are listed.
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`repo`|`string` *optional*|Optional repository name. If provided with owner, only pull requests for this repository are listed.
+`sort`|`string` *optional*|Sort field by number of matches of categories, defaults to best match
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`search_repositories`**
+Find GitHub repositories by name, description, readme, topics, or other metadata. Perfect for discovering projects, finding examples, or locating specific repositories across GitHub.
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Repository search query. Examples: 'machine learning in:name stars:>1000 language:python', 'topic:react', 'user:facebook'. Supports advanced search syntax for precise filtering.
+`minimal_output`|`boolean` *optional*|Return minimal repository information (default: true). When false, returns full GitHub API repository objects.
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`search_users`**
+Find GitHub users by username, real name, or other profile information. Useful for locating developers, contributors, or team members.
+Parameters|Type|Description
+-|-|-
+`query`|`string`|User search query. Examples: 'john smith', 'location:seattle', 'followers:>100'. Search is automatically scoped to type:user.
+`order`|`string` *optional*|Sort order
+`page`|`number` *optional*|Page number for pagination (min 1)
+`perPage`|`number` *optional*|Results per page for pagination (min 1, max 100)
+`sort`|`string` *optional*|Sort users by number of followers or repositories, or when the person joined GitHub.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`star_repository`**
+Star a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+
+---
+#### Tool: **`submit_pending_pull_request_review`**
+Submit the requester's latest pending pull request review, normally this is a final step after creating a pending review, adding comments first, unless you know that the user already did the first two steps, you should check before calling this.
+Parameters|Type|Description
+-|-|-
+`event`|`string`|The event to perform
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+`body`|`string` *optional*|The text of the review comment
+
+---
+#### Tool: **`unstar_repository`**
+Unstar a GitHub repository
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+
+---
+#### Tool: **`update_gist`**
+Update an existing gist
+Parameters|Type|Description
+-|-|-
+`content`|`string`|Content for the file
+`filename`|`string`|Filename to update or create
+`gist_id`|`string`|ID of the gist to update
+`description`|`string` *optional*|Updated description of the gist
+
+---
+#### Tool: **`update_issue`**
+Update an existing issue in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`issue_number`|`number`|Issue number to update
+`owner`|`string`|Repository owner
+`repo`|`string`|Repository name
+`assignees`|`array` *optional*|New assignees
+`body`|`string` *optional*|New description
+`duplicate_of`|`number` *optional*|Issue number that this issue is a duplicate of. Only used when state_reason is 'duplicate'.
+`labels`|`array` *optional*|New labels
+`milestone`|`number` *optional*|New milestone number
+`state`|`string` *optional*|New state
+`state_reason`|`string` *optional*|Reason for the state change. Ignored unless state is changed.
+`title`|`string` *optional*|New title
+`type`|`string` *optional*|New issue type
+
+---
+#### Tool: **`update_pull_request`**
+Update an existing pull request in a GitHub repository.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number to update
+`repo`|`string`|Repository name
+`base`|`string` *optional*|New base branch name
+`body`|`string` *optional*|New description
+`draft`|`boolean` *optional*|Mark pull request as draft (true) or ready for review (false)
+`maintainer_can_modify`|`boolean` *optional*|Allow maintainer edits
+`reviewers`|`array` *optional*|GitHub usernames to request reviews from
+`state`|`string` *optional*|New state
+`title`|`string` *optional*|New title
+
+---
+#### Tool: **`update_pull_request_branch`**
+Update the branch of a pull request with the latest changes from the base branch.
+Parameters|Type|Description
+-|-|-
+`owner`|`string`|Repository owner
+`pullNumber`|`number`|Pull request number
+`repo`|`string`|Repository name
+`expectedHeadSha`|`string` *optional*|The expected SHA of the pull request's HEAD ref
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "github-official": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GITHUB_PERSONAL_ACCESS_TOKEN",
+        "ghcr.io/github/github-mcp-server"
+      ],
+      "env": {
+        "GITHUB_PERSONAL_ACCESS_TOKEN": "<YOUR_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/gmail-mcp.md
+++ b/docs/mcp/gmail-mcp.md
@@ -1,0 +1,92 @@
+# Gmail MCP Server MCP Server
+
+A Model Context Protocol server for Gmail operations using IMAP/SMTP with app password authentication. Supports listing messages, searching emails, and sending messages.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[yashtekwani/gmail-mcp](https://hub.docker.com/repository/docker/yashtekwani/gmail-mcp)
+**Author**|[Sallytion](https://github.com/Sallytion)
+**Repository**|https://github.com/Sallytion/Gmail-MCP
+**Dockerfile**|https://github.com/Sallytion/Gmail-MCP/blob/main/Dockerfile
+**Docker Image built by**|Sallytion
+**Docker Scout Health Score**|Not available
+**Verify Signature**|Not available
+**Licence**|
+
+## Available Tools (3)
+Tools provided by this Server|Short Description
+-|-
+`listMessages`|List recent messages from Gmail inbox|
+`findMessage`|Search for messages containing specific words or phrases|
+`sendMessage`|Send an email message|
+
+---
+## Tools Details
+
+#### Tool: **`listMessages`**
+List recent messages from Gmail inbox
+Parameters|Type|Description
+-|-|-
+`count`|`number`|Number of messages to retrieve (default: 10, max: 100)
+
+---
+#### Tool: **`findMessage`**
+Search for messages containing specific words or phrases
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Search query (supports Gmail search syntax)
+
+---
+#### Tool: **`sendMessage`**
+Send an email message
+Parameters|Type|Description
+-|-|-
+`to`|`string`|Recipient email address
+`subject`|`string`|Email subject
+`body`|`string`|Email message body
+`cc`|`string`|CC email address (optional)
+`bcc`|`string`|BCC email address (optional)
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "gmail-mcp": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "EMAIL_ADDRESS",
+        "-e",
+        "IMAP_HOST",
+        "-e",
+        "IMAP_PORT",
+        "-e",
+        "SMTP_HOST",
+        "-e",
+        "SMTP_PORT",
+        "-e",
+        "EMAIL_PASSWORD",
+        "yashtekwani/gmail-mcp"
+      ],
+      "env": {
+        "EMAIL_ADDRESS": "your-email@gmail.com",
+        "IMAP_HOST": "imap.gmail.com",
+        "IMAP_PORT": "993",
+        "SMTP_HOST": "smtp.gmail.com",
+        "SMTP_PORT": "587",
+        "EMAIL_PASSWORD": "<your-gmail-app-password>"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/google-maps-comprehensive.md
+++ b/docs/mcp/google-maps-comprehensive.md
@@ -1,0 +1,113 @@
+# Google Maps Comprehensive MCP MCP Server
+
+Complete Google Maps integration with 8 tools including geocoding, places search, directions, elevation data, and more using Google's latest APIs.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/google-maps-comprehensive](https://hub.docker.com/repository/docker/mcp/google-maps-comprehensive)
+**Author**|[vicpeacock](https://github.com/vicpeacock)
+**Repository**|https://github.com/vicpeacock/google-maps-comprehensive-mcp
+**Dockerfile**|https://github.com/vicpeacock/google-maps-comprehensive-mcp/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/google-maps-comprehensive)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/google-maps-comprehensive --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|
+
+## Available Tools (8)
+Tools provided by this Server|Short Description
+-|-
+`maps_directions`|Get directions between two locations using Google Routes API|
+`maps_distance_matrix`|Calculate distances and travel times between multiple origins and destinations|
+`maps_elevation`|Get elevation data for geographic points using Google Elevation API|
+`maps_geocode`|Convert address to coordinates using Google Geocoding API|
+`maps_ping`|Check if the Google Maps MCP server is alive|
+`maps_place_details`|Get detailed information about a place using Google Places API|
+`maps_reverse_geocode`|Get address from latitude/longitude using Google Places Nearby|
+`maps_search_places`|Search places using Google Places API (New)|
+
+---
+## Tools Details
+
+#### Tool: **`maps_directions`**
+Get directions between two locations using Google Routes API
+Parameters|Type|Description
+-|-|-
+`destination`|`string`|Destination address
+`origin`|`string`|Origin address
+`travelMode`|`string` *optional*|Travel mode
+
+---
+#### Tool: **`maps_distance_matrix`**
+Calculate distances and travel times between multiple origins and destinations
+Parameters|Type|Description
+-|-|-
+`destinations`|`array`|Array of destination addresses
+`origins`|`array`|Array of origin addresses
+`mode`|`string` *optional*|Travel mode
+
+---
+#### Tool: **`maps_elevation`**
+Get elevation data for geographic points using Google Elevation API
+Parameters|Type|Description
+-|-|-
+`locations`|`array`|Array of locations to get elevation for
+
+---
+#### Tool: **`maps_geocode`**
+Convert address to coordinates using Google Geocoding API
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Address to geocode
+
+---
+#### Tool: **`maps_ping`**
+Check if the Google Maps MCP server is alive
+#### Tool: **`maps_place_details`**
+Get detailed information about a place using Google Places API
+Parameters|Type|Description
+-|-|-
+`place_id`|`string`|Google Place ID
+
+---
+#### Tool: **`maps_reverse_geocode`**
+Get address from latitude/longitude using Google Places Nearby
+Parameters|Type|Description
+-|-|-
+`latitude`|`number`|Latitude coordinate
+`longitude`|`number`|Longitude coordinate
+
+---
+#### Tool: **`maps_search_places`**
+Search places using Google Places API (New)
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Search query for places
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "google-maps-comprehensive": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GOOGLE_MAPS_API_KEY",
+        "mcp/google-maps-comprehensive"
+      ],
+      "env": {
+        "GOOGLE_MAPS_API_KEY": "<YOUR_GOOGLE_MAPS_API_KEY>"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/grafana.md
+++ b/docs/mcp/grafana.md
@@ -1,0 +1,605 @@
+# Grafana MCP Server
+
+MCP server for Grafana.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/grafana](https://hub.docker.com/repository/docker/mcp/grafana)
+**Author**|[grafana](https://github.com/grafana)
+**Repository**|https://github.com/grafana/mcp-grafana
+**Dockerfile**|https://github.com/grafana/mcp-grafana/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/grafana)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/grafana --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|Apache License 2.0
+
+## Available Tools (45)
+Tools provided by this Server|Short Description
+-|-
+`add_activity_to_incident`|Add activity to incident|
+`create_incident`|Create incident|
+`fetch_pyroscope_profile`|Fetch Pyroscope profile|
+`find_error_pattern_logs`|Find error patterns in logs|
+`find_slow_requests`|Find slow requests|
+`generate_deeplink`|Generate navigation deeplink|
+`get_alert_group`|Get IRM alert group|
+`get_alert_rule_by_uid`|Get alert rule details|
+`get_assertions`|Get assertions summary|
+`get_current_oncall_users`|Get current on-call users|
+`get_dashboard_by_uid`|Get dashboard details|
+`get_dashboard_panel_queries`|Get dashboard panel queries|
+`get_dashboard_property`|Get dashboard property|
+`get_dashboard_summary`|Get dashboard summary|
+`get_datasource_by_name`|Get datasource by name|
+`get_datasource_by_uid`|Get datasource by UID|
+`get_incident`|Get incident details|
+`get_oncall_shift`|Get OnCall shift|
+`get_sift_analysis`|Get Sift analysis|
+`get_sift_investigation`|Get Sift investigation|
+`list_alert_groups`|List IRM alert groups|
+`list_alert_rules`|List alert rules|
+`list_contact_points`|List notification contact points|
+`list_datasources`|List datasources|
+`list_incidents`|List incidents|
+`list_loki_label_names`|List Loki label names|
+`list_loki_label_values`|List Loki label values|
+`list_oncall_schedules`|List OnCall schedules|
+`list_oncall_teams`|List OnCall teams|
+`list_oncall_users`|List OnCall users|
+`list_prometheus_label_names`|List Prometheus label names|
+`list_prometheus_label_values`|List Prometheus label values|
+`list_prometheus_metric_metadata`|List Prometheus metric metadata|
+`list_prometheus_metric_names`|List Prometheus metric names|
+`list_pyroscope_label_names`|List Pyroscope label names|
+`list_pyroscope_label_values`|List Pyroscope label values|
+`list_pyroscope_profile_types`|List Pyroscope profile types|
+`list_sift_investigations`|List Sift investigations|
+`list_teams`|List teams|
+`list_users_by_org`|List users by org|
+`query_loki_logs`|Query Loki logs|
+`query_loki_stats`|Get Loki log statistics|
+`query_prometheus`|Query Prometheus metrics|
+`search_dashboards`|Search dashboards|
+`update_dashboard`|Create or update dashboard|
+
+---
+## Tools Details
+
+#### Tool: **`add_activity_to_incident`**
+Add a note (userNote activity) to an existing incident's timeline using its ID. The note body can include URLs which will be attached as context. Use this to add context to an incident.
+Parameters|Type|Description
+-|-|-
+`body`|`string` *optional*|The body of the activity. URLs will be parsed and attached as context
+`eventTime`|`string` *optional*|The time that the activity occurred. If not provided, the current time will be used
+`incidentId`|`string` *optional*|The ID of the incident to add the activity to
+
+---
+#### Tool: **`create_incident`**
+Create a new Grafana incident. Requires title, severity, and room prefix. Allows setting status and labels. This tool should be used judiciously and sparingly, and only after confirmation from the user, as it may notify or alarm lots of people.
+Parameters|Type|Description
+-|-|-
+`attachCaption`|`string` *optional*|The caption of the attachment
+`attachUrl`|`string` *optional*|The URL of the attachment
+`isDrill`|`boolean` *optional*|Whether the incident is a drill incident
+`labels`|`array` *optional*|The labels to add to the incident
+`roomPrefix`|`string` *optional*|The prefix of the room to create the incident in
+`severity`|`string` *optional*|The severity of the incident
+`status`|`string` *optional*|The status of the incident
+`title`|`string` *optional*|The title of the incident
+
+---
+#### Tool: **`fetch_pyroscope_profile`**
+Fetches a profile from a Pyroscope data source for a given time range. By default, the time range is tha past 1 hour.
+The profile type is required, available profile types can be fetched via the list_pyroscope_profile_types tool. Not all
+profile types are available for every service. Expect some queries to return empty result sets, this indicates the
+profile type does not exist for that query. In such a case, consider trying a related profile type or giving up.
+Matchers are not required, but highly recommended, they are generally used to select an application by the service_name
+label (e.g. {service_name="foo"}). Use the list_pyroscope_label_names tool to fetch available label names, and the
+list_pyroscope_label_values tool to fetch available label values. The returned profile is in DOT format.
+Parameters|Type|Description
+-|-|-
+`data_source_uid`|`string`|The UID of the datasource to query
+`profile_type`|`string`|Type profile type, use the list_pyroscope_profile_types tool to fetch available profile types
+`end_rfc_3339`|`string` *optional*|Optionally, the end time of the query in RFC3339 format (defaults to now)
+`matchers`|`string` *optional*|Optionally, Prometheus style matchers used to filter the result set (defaults to: {})
+`max_node_depth`|`integer` *optional*|Optionally, the maximum depth of nodes in the resulting profile. Less depth results in smaller profiles that execute faster, more depth result in larger profiles that have more detail. A value of -1 indicates to use an unbounded node depth (default: 100). Reducing max node depth from the default will negatively impact the accuracy of the profile
+`start_rfc_3339`|`string` *optional*|Optionally, the start time of the query in RFC3339 format (defaults to 1 hour ago)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`find_error_pattern_logs`**
+Searches Loki logs for elevated error patterns compared to the last day's average, waits for the analysis to complete, and returns the results including any patterns found.
+Parameters|Type|Description
+-|-|-
+`labels`|`object`|Labels to scope the analysis
+`name`|`string`|The name of the investigation
+`end`|`string` *optional*|End time for the investigation. Defaults to now if not specified.
+`start`|`string` *optional*|Start time for the investigation. Defaults to 30 minutes ago if not specified.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`find_slow_requests`**
+Searches relevant Tempo datasources for slow requests, waits for the analysis to complete, and returns the results.
+Parameters|Type|Description
+-|-|-
+`labels`|`object`|Labels to scope the analysis
+`name`|`string`|The name of the investigation
+`end`|`string` *optional*|End time for the investigation. Defaults to now if not specified.
+`start`|`string` *optional*|Start time for the investigation. Defaults to 30 minutes ago if not specified.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`generate_deeplink`**
+Generate deeplink URLs for Grafana resources. Supports dashboards (requires dashboardUid), panels (requires dashboardUid and panelId), and Explore queries (requires datasourceUid). Optionally accepts time range and additional query parameters.
+Parameters|Type|Description
+-|-|-
+`resourceType`|`string`|Type of resource: dashboard, panel, or explore
+`dashboardUid`|`string` *optional*|Dashboard UID (required for dashboard and panel types)
+`datasourceUid`|`string` *optional*|Datasource UID (required for explore type)
+`panelId`|`integer` *optional*|Panel ID (required for panel type)
+`queryParams`|`object` *optional*|Additional query parameters
+`timeRange`|`object` *optional*|Time range for the link
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_alert_group`**
+Get a specific alert group from Grafana OnCall by its ID. Returns the full alert group details.
+Parameters|Type|Description
+-|-|-
+`alertGroupId`|`string`|The ID of the alert group to retrieve
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_alert_rule_by_uid`**
+Retrieves the full configuration and detailed status of a specific Grafana alert rule identified by its unique ID (UID). The response includes fields like title, condition, query data, folder UID, rule group, state settings (no data, error), evaluation interval, annotations, and labels.
+Parameters|Type|Description
+-|-|-
+`uid`|`string`|The uid of the alert rule
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_assertions`**
+Get assertion summary for a given entity with its type, name, env, site, namespace, and a time range
+Parameters|Type|Description
+-|-|-
+`endTime`|`string`|The end time in RFC3339 format
+`startTime`|`string`|The start time in RFC3339 format
+`entityName`|`string` *optional*|The name of the entity to list
+`entityType`|`string` *optional*|The type of the entity to list (e.g. Service, Node, Pod, etc.)
+`env`|`string` *optional*|The env of the entity to list
+`namespace`|`string` *optional*|The namespace of the entity to list
+`site`|`string` *optional*|The site of the entity to list
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_current_oncall_users`**
+Get the list of users currently on-call for a specific Grafana OnCall schedule ID. Returns the schedule ID, name, and a list of detailed user objects for those currently on call.
+Parameters|Type|Description
+-|-|-
+`scheduleId`|`string`|The ID of the schedule to get current on-call users for
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_dashboard_by_uid`**
+Retrieves the complete dashboard, including panels, variables, and settings, for a specific dashboard identified by its UID. WARNING: Large dashboards can consume significant context window space. Consider using get_dashboard_summary for overview or get_dashboard_property for specific data instead.
+Parameters|Type|Description
+-|-|-
+`uid`|`string`|The UID of the dashboard
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_dashboard_panel_queries`**
+Use this tool to retrieve panel queries and information from a Grafana dashboard. When asked about panel queries, queries in a dashboard, or what queries a dashboard contains, call this tool with the dashboard UID. The datasource is an object with fields `uid` (which may be a concrete UID or a template variable like "$datasource") and `type`. If the datasource UID is a template variable, it won't be usable directly for queries. Returns an array of objects, each representing a panel, with fields: title, query, and datasource (an object with uid and type).
+Parameters|Type|Description
+-|-|-
+`uid`|`string`|The UID of the dashboard
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_dashboard_property`**
+Get specific parts of a dashboard using JSONPath expressions to minimize context window usage. Common paths: '$.title' (title)\, '$.panels[*].title' (all panel titles)\, '$.panels[0]' (first panel)\, '$.templating.list' (variables)\, '$.tags' (tags)\, '$.panels[*].targets[*].expr' (all queries). Use this instead of get_dashboard_by_uid when you only need specific dashboard properties.
+Parameters|Type|Description
+-|-|-
+`jsonPath`|`string`|JSONPath expression to extract specific data (e.g., '$.panels[0].title' for first panel title, '$.panels[*].title' for all panel titles, '$.templating.list' for variables)
+`uid`|`string`|The UID of the dashboard
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_dashboard_summary`**
+Get a compact summary of a dashboard including title\, panel count\, panel types\, variables\, and other metadata without the full JSON. Use this for dashboard overview and planning modifications without consuming large context windows.
+Parameters|Type|Description
+-|-|-
+`uid`|`string`|The UID of the dashboard
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_datasource_by_name`**
+Retrieves detailed information about a specific datasource using its name. Returns the full datasource model, including UID, type, URL, access settings, JSON data, and secure JSON field status.
+Parameters|Type|Description
+-|-|-
+`name`|`string`|The name of the datasource
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_datasource_by_uid`**
+Retrieves detailed information about a specific datasource using its UID. Returns the full datasource model, including name, type, URL, access settings, JSON data, and secure JSON field status.
+Parameters|Type|Description
+-|-|-
+`uid`|`string`|The uid of the datasource
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_incident`**
+Get a single incident by ID. Returns the full incident details including title, status, severity, labels, timestamps, and other metadata.
+Parameters|Type|Description
+-|-|-
+`id`|`string` *optional*|The ID of the incident to retrieve
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_oncall_shift`**
+Get detailed information for a specific Grafana OnCall shift using its ID. A shift represents a designated time period within a schedule when users are actively on-call. Returns the full shift details.
+Parameters|Type|Description
+-|-|-
+`shiftId`|`string`|The ID of the shift to get details for
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_sift_analysis`**
+Retrieves a specific analysis from an investigation by its UUID. The investigation ID and analysis ID should be provided as strings in UUID format.
+Parameters|Type|Description
+-|-|-
+`analysisId`|`string`|The UUID of the specific analysis to retrieve
+`investigationId`|`string`|The UUID of the investigation as a string (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b')
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_sift_investigation`**
+Retrieves an existing Sift investigation by its UUID. The ID should be provided as a string in UUID format (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b').
+Parameters|Type|Description
+-|-|-
+`id`|`string`|The UUID of the investigation as a string (e.g. '02adab7c-bf5b-45f2-9459-d71a2c29e11b')
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_alert_groups`**
+List alert groups from Grafana OnCall with filtering options. Supports filtering by alert group ID, route ID, integration ID, state (new, acknowledged, resolved, silenced), team ID, time range, labels, and name. For time ranges, use format '{start}_{end}' ISO 8601 timestamp range (e.g., '2025-01-19T00:00:00_2025-01-19T23:59:59' for a specific day). For labels, use format 'key:value' (e.g., ['env:prod', 'severity:high']). Returns a list of alert group objects with their details. Supports pagination.
+Parameters|Type|Description
+-|-|-
+`id`|`string` *optional*|Filter by specific alert group ID
+`integrationId`|`string` *optional*|Filter by integration ID
+`labels`|`array` *optional*|Filter by labels in format key:value (e.g., ['env:prod', 'severity:high'])
+`name`|`string` *optional*|Filter by alert group name
+`page`|`integer` *optional*|The page number to return
+`routeId`|`string` *optional*|Filter by route ID
+`startedAt`|`string` *optional*|Filter by time range in format '{start}_{end}' ISO 8601 timestamp range (UTC assumed, no timezone indicator needed) (e.g., '2025-01-19T00:00:00_2025-01-19T23:59:59')
+`state`|`string` *optional*|Filter by alert group state (one of: new, acknowledged, resolved, silenced)
+`teamId`|`string` *optional*|Filter by team ID
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_alert_rules`**
+Lists Grafana alert rules, returning a summary including UID, title, current state (e.g., 'pending', 'firing', 'inactive'), and labels. Supports filtering by labels using selectors and pagination. Example label selector: `[{'name': 'severity', 'type': '=', 'value': 'critical'}]`. Inactive state means the alert state is normal, not firing
+Parameters|Type|Description
+-|-|-
+`label_selectors`|`array` *optional*|Optionally, a list of matchers to filter alert rules by labels
+`limit`|`integer` *optional*|The maximum number of results to return. Default is 100.
+`page`|`integer` *optional*|The page number to return.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_contact_points`**
+Lists Grafana notification contact points, returning a summary including UID, name, and type for each. Supports filtering by name - exact match - and limiting the number of results.
+Parameters|Type|Description
+-|-|-
+`limit`|`integer` *optional*|The maximum number of results to return. Default is 100.
+`name`|`string` *optional*|Filter contact points by name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_datasources`**
+List available Grafana datasources. Optionally filter by datasource type (e.g., 'prometheus', 'loki'). Returns a summary list including ID, UID, name, type, and default status.
+Parameters|Type|Description
+-|-|-
+`type`|`string` *optional*|The type of datasources to search for. For example, 'prometheus', 'loki', 'tempo', etc...
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_incidents`**
+List Grafana incidents. Allows filtering by status ('active', 'resolved') and optionally including drill incidents. Returns a preview list with basic details.
+Parameters|Type|Description
+-|-|-
+`drill`|`boolean` *optional*|Whether to include drill incidents
+`limit`|`integer` *optional*|The maximum number of incidents to return
+`status`|`string` *optional*|The status of the incidents to include. Valid values: 'active', 'resolved'
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_loki_label_names`**
+Lists all available label names (keys) found in logs within a specified Loki datasource and time range. Returns a list of unique label strings (e.g., `["app", "env", "pod"]`). If the time range is not provided, it defaults to the last hour.
+Parameters|Type|Description
+-|-|-
+`datasourceUid`|`string`|The UID of the datasource to query
+`endRfc3339`|`string` *optional*|Optionally, the end time of the query in RFC3339 format (defaults to now)
+`startRfc3339`|`string` *optional*|Optionally, the start time of the query in RFC3339 format (defaults to 1 hour ago)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_loki_label_values`**
+Retrieves all unique values associated with a specific `labelName` within a Loki datasource and time range. Returns a list of string values (e.g., for `labelName="env"`, might return `["prod", "staging", "dev"]`). Useful for discovering filter options. Defaults to the last hour if the time range is omitted.
+Parameters|Type|Description
+-|-|-
+`datasourceUid`|`string`|The UID of the datasource to query
+`labelName`|`string`|The name of the label to retrieve values for (e.g. 'app', 'env', 'pod')
+`endRfc3339`|`string` *optional*|Optionally, the end time of the query in RFC3339 format (defaults to now)
+`startRfc3339`|`string` *optional*|Optionally, the start time of the query in RFC3339 format (defaults to 1 hour ago)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_oncall_schedules`**
+List Grafana OnCall schedules, optionally filtering by team ID. If a specific schedule ID is provided, retrieves details for only that schedule. Returns a list of schedule summaries including ID, name, team ID, timezone, and shift IDs. Supports pagination.
+Parameters|Type|Description
+-|-|-
+`page`|`integer` *optional*|The page number to return (1-based)
+`scheduleId`|`string` *optional*|The ID of the schedule to get details for. If provided, returns only that schedule's details
+`teamId`|`string` *optional*|The ID of the team to list schedules for
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_oncall_teams`**
+List teams configured in Grafana OnCall. Returns a list of team objects with their details. Supports pagination.
+Parameters|Type|Description
+-|-|-
+`page`|`integer` *optional*|The page number to return
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_oncall_users`**
+List users from Grafana OnCall. Can retrieve all users, a specific user by ID, or filter by username. Returns a list of user objects with their details. Supports pagination.
+Parameters|Type|Description
+-|-|-
+`page`|`integer` *optional*|The page number to return
+`userId`|`string` *optional*|The ID of the user to get details for. If provided, returns only that user's details
+`username`|`string` *optional*|The username to filter users by. If provided, returns only the user matching this username
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_prometheus_label_names`**
+List label names in a Prometheus datasource. Allows filtering by series selectors and time range.
+Parameters|Type|Description
+-|-|-
+`datasourceUid`|`string`|The UID of the datasource to query
+`endRfc3339`|`string` *optional*|Optionally, the end time of the time range to filter the results by
+`limit`|`integer` *optional*|Optionally, the maximum number of results to return
+`matches`|`array` *optional*|Optionally, a list of label matchers to filter the results by
+`startRfc3339`|`string` *optional*|Optionally, the start time of the time range to filter the results by
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_prometheus_label_values`**
+Get the values for a specific label name in Prometheus. Allows filtering by series selectors and time range.
+Parameters|Type|Description
+-|-|-
+`datasourceUid`|`string`|The UID of the datasource to query
+`labelName`|`string`|The name of the label to query
+`endRfc3339`|`string` *optional*|Optionally, the end time of the query
+`limit`|`integer` *optional*|Optionally, the maximum number of results to return
+`matches`|`array` *optional*|Optionally, a list of selectors to filter the results by
+`startRfc3339`|`string` *optional*|Optionally, the start time of the query
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_prometheus_metric_metadata`**
+List Prometheus metric metadata. Returns metadata about metrics currently scraped from targets. Note: This endpoint is experimental.
+Parameters|Type|Description
+-|-|-
+`datasourceUid`|`string`|The UID of the datasource to query
+`limit`|`integer` *optional*|The maximum number of metrics to return
+`limitPerMetric`|`integer` *optional*|The maximum number of metrics to return per metric
+`metric`|`string` *optional*|The metric to query
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_prometheus_metric_names`**
+List metric names in a Prometheus datasource. Retrieves all metric names and then filters them locally using the provided regex. Supports pagination.
+Parameters|Type|Description
+-|-|-
+`datasourceUid`|`string`|The UID of the datasource to query
+`limit`|`integer` *optional*|The maximum number of results to return
+`page`|`integer` *optional*|The page number to return
+`regex`|`string` *optional*|The regex to match against the metric names
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_pyroscope_label_names`**
+Lists all available label names (keys) found in profiles within a specified Pyroscope datasource, time range, and
+optional label matchers. Label matchers are typically used to qualify a service name ({service_name="foo"}). Returns a
+list of unique label strings (e.g., ["app", "env", "pod"]). Label names with double underscores (e.g. __name__) are
+internal and rarely useful to users. If the time range is not provided, it defaults to the last hour.
+Parameters|Type|Description
+-|-|-
+`data_source_uid`|`string`|The UID of the datasource to query
+`end_rfc_3339`|`string` *optional*|Optionally, the end time of the query in RFC3339 format (defaults to now)
+`matchers`|`string` *optional*|
+`start_rfc_3339`|`string` *optional*|Optionally, the start time of the query in RFC3339 format (defaults to 1 hour ago)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_pyroscope_label_values`**
+Lists all available label values for a particular label name found in profiles within a specified Pyroscope datasource,
+time range, and optional label matchers. Label matchers are typically used to qualify a service name ({service_name="foo"}).
+Returns a list of unique label strings (e.g. for label name "env": ["dev", "staging", "prod"]). If the time range
+is not provided, it defaults to the last hour.
+Parameters|Type|Description
+-|-|-
+`data_source_uid`|`string`|The UID of the datasource to query
+`name`|`string`|A label name
+`end_rfc_3339`|`string` *optional*|Optionally, the end time of the query in RFC3339 format (defaults to now)
+`matchers`|`string` *optional*|Optionally, Prometheus style matchers used to filter the result set (defaults to: {})
+`start_rfc_3339`|`string` *optional*|Optionally, the start time of the query in RFC3339 format (defaults to 1 hour ago)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_pyroscope_profile_types`**
+Lists all available profile types available in a specified Pyroscope datasource and time range. Returns a list of all
+available profile types (example profile type: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"). A profile type has the
+following structure: <name>:<sample type>:<sample unit>:<period type>:<period unit>. Not all profile types are available
+for every service. If the time range is not provided, it defaults to the last hour.
+Parameters|Type|Description
+-|-|-
+`data_source_uid`|`string`|The UID of the datasource to query
+`end_rfc_3339`|`string` *optional*|Optionally, the end time of the query in RFC3339 format (defaults to now)
+`start_rfc_3339`|`string` *optional*|Optionally, the start time of the query in RFC3339 format (defaults to 1 hour ago)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_sift_investigations`**
+Retrieves a list of Sift investigations with an optional limit. If no limit is specified, defaults to 10 investigations.
+Parameters|Type|Description
+-|-|-
+`limit`|`integer` *optional*|Maximum number of investigations to return. Defaults to 10 if not specified.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_teams`**
+Search for Grafana teams by a query string. Returns a list of matching teams with details like name, ID, and URL.
+Parameters|Type|Description
+-|-|-
+`query`|`string` *optional*|The query to search for teams. Can be left empty to fetch all teams
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_users_by_org`**
+List users by organization. Returns a list of users with details like userid, email, role etc.
+#### Tool: **`query_loki_logs`**
+Executes a LogQL query against a Loki datasource to retrieve log entries or metric values. Returns a list of results, each containing a timestamp, labels, and either a log line (`line`) or a numeric metric value (`value`). Defaults to the last hour, a limit of 10 entries, and 'backward' direction (newest first). Supports full LogQL syntax for log and metric queries (e.g., `{app="foo"} |= "error"`, `rate({app="bar"}[1m])`). Prefer using `query_loki_stats` first to check stream size and `list_loki_label_names` and `list_loki_label_values` to verify labels exist.
+Parameters|Type|Description
+-|-|-
+`datasourceUid`|`string`|The UID of the datasource to query
+`logql`|`string`|The LogQL query to execute against Loki. This can be a simple label matcher or a complex query with filters, parsers, and expressions. Supports full LogQL syntax including label matchers, filter operators, pattern expressions, and pipeline operations.
+`direction`|`string` *optional*|Optionally, the direction of the query: 'forward' (oldest first) or 'backward' (newest first, default)
+`endRfc3339`|`string` *optional*|Optionally, the end time of the query in RFC3339 format
+`limit`|`integer` *optional*|Optionally, the maximum number of log lines to return (default: 10, max: 100)
+`startRfc3339`|`string` *optional*|Optionally, the start time of the query in RFC3339 format
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`query_loki_stats`**
+Retrieves statistics about log streams matching a given LogQL *selector* within a Loki datasource and time range. Returns an object containing the count of streams, chunks, entries, and total bytes (e.g., `{"streams": 5, "chunks": 50, "entries": 10000, "bytes": 512000}`). The `logql` parameter **must** be a simple label selector (e.g., `{app="nginx", env="prod"}`) and does not support line filters, parsers, or aggregations. Defaults to the last hour if the time range is omitted.
+Parameters|Type|Description
+-|-|-
+`datasourceUid`|`string`|The UID of the datasource to query
+`logql`|`string`|The LogQL matcher expression to execute. This parameter only accepts label matcher expressions and does not support full LogQL queries. Line filters, pattern operations, and metric aggregations are not supported by the stats API endpoint. Only simple label selectors can be used here.
+`endRfc3339`|`string` *optional*|Optionally, the end time of the query in RFC3339 format
+`startRfc3339`|`string` *optional*|Optionally, the start time of the query in RFC3339 format
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`query_prometheus`**
+Query Prometheus using a PromQL expression. Supports both instant queries (at a single point in time) and range queries (over a time range). Time can be specified either in RFC3339 format or as relative time expressions like 'now', 'now-1h', 'now-30m', etc.
+Parameters|Type|Description
+-|-|-
+`datasourceUid`|`string`|The UID of the datasource to query
+`expr`|`string`|The PromQL expression to query
+`startTime`|`string`|The start time. Supported formats are RFC3339 or relative to now (e.g. 'now', 'now-1.5h', 'now-2h45m'). Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h', 'd'.
+`endTime`|`string` *optional*|The end time. Required if queryType is 'range', ignored if queryType is 'instant' Supported formats are RFC3339 or relative to now (e.g. 'now', 'now-1.5h', 'now-2h45m'). Valid time units are 'ns', 'us' (or 'µs'), 'ms', 's', 'm', 'h', 'd'.
+`queryType`|`string` *optional*|The type of query to use. Either 'range' or 'instant'
+`stepSeconds`|`integer` *optional*|The time series step size in seconds. Required if queryType is 'range', ignored if queryType is 'instant'
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`search_dashboards`**
+Search for Grafana dashboards by a query string. Returns a list of matching dashboards with details like title, UID, folder, tags, and URL.
+Parameters|Type|Description
+-|-|-
+`query`|`string` *optional*|The query to search for
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`update_dashboard`**
+Create or update a dashboard using either full JSON or efficient patch operations. For new dashboards\, provide the 'dashboard' field. For updating existing dashboards\, use 'uid' + 'operations' for better context window efficiency. Patch operations support complex JSONPaths like '$.panels[0].targets[0].expr'\, '$.panels[1].title'\, '$.panels[2].targets[0].datasource'\, etc. Supports appending to arrays using '/- ' syntax: '$.panels/- ' appends to panels array\, '$.panels[2]/- ' appends to nested array at index 2.
+Parameters|Type|Description
+-|-|-
+`dashboard`|`object` *optional*|The full dashboard JSON. Use for creating new dashboards or complete updates. Large dashboards consume significant context - consider using patches for small changes.
+`folderUid`|`string` *optional*|The UID of the dashboard's folder
+`message`|`string` *optional*|Set a commit message for the version history
+`operations`|`array` *optional*|Array of patch operations for targeted updates. More efficient than full dashboard JSON for small changes.
+`overwrite`|`boolean` *optional*|Overwrite the dashboard if it exists. Otherwise create one
+`uid`|`string` *optional*|UID of existing dashboard to update. Required when using patch operations.
+`userId`|`integer` *optional*|ID of the user making the change
+
+*This tool may perform destructive updates.*
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "grafana": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "GRAFANA_URL",
+        "-e",
+        "GRAFANA_API_KEY",
+        "mcp/grafana",
+        "--transport=stdio"
+      ],
+      "env": {
+        "GRAFANA_URL": "http://localhost:3000",
+        "GRAFANA_API_KEY": "<your service account token>"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/heroku.md
+++ b/docs/mcp/heroku.md
@@ -1,0 +1,412 @@
+# Heroku MCP Server
+
+Heroku Platform MCP Server using the Heroku CLI.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/heroku](https://hub.docker.com/repository/docker/mcp/heroku)
+**Author**|[heroku](https://github.com/heroku)
+**Repository**|https://github.com/heroku/heroku-mcp-server
+**Dockerfile**|https://github.com/heroku/heroku-mcp-server/blob/refs/pull/24/merge/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/heroku)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/heroku --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|Apache License 2.0
+
+## Available Tools (34)
+Tools provided by this Server|Short Description
+-|-
+`create_addon`|Create add-on: specify service, plan, custom names|
+`create_app`|Create app: custom name, region (US/EU), team, private space|
+`deploy_one_off_dyno`|Run code/commands in Heroku one-off dyno with network and filesystem access.|
+`deploy_to_heroku`|Use for all deployments.|
+`get_addon_info`|Get add-on details: plan, state, billing|
+`get_app_info`|Get app details: config, dynos, addons, access, domains|
+`get_app_logs`|App logs: monitor/debug/filter by dyno/process/source|
+`list_addon_plans`|List service plans: features, pricing, availability|
+`list_addon_services`|List available add-on services and features|
+`list_addons`|List add-ons: all apps or specific app, detailed metadata|
+`list_apps`|List Heroku apps: owned, collaborator access, team/space filtering|
+`list_private_spaces`|Lists Heroku Private Spaces with CIDR blocks, regions, compliance and capacity details.|
+`list_teams`|Lists accessible Heroku Teams.|
+`maintenance_off`|Disable maintenance mode and restore normal app operations|
+`maintenance_on`|Enable maintenance mode and redirect traffic for a Heroku app|
+`pg_backups`|Manage backups: schedules, status, verification, recovery|
+`pg_credentials`|Manage access: credentials, permissions, security, monitoring|
+`pg_info`|View database status: config, metrics, resources, health|
+`pg_kill`|Stop processes: stuck queries, blocking transactions, runaway operations|
+`pg_locks`|Analyze locks: blocked queries, deadlocks, concurrency|
+`pg_maintenance`|Track maintenance: windows, schedules, progress, planning|
+`pg_outliers`|Find resource-heavy queries: performance, patterns, optimization|
+`pg_ps`|Monitor active queries: progress, resources, performance|
+`pg_psql`|Execute SQL queries: analyze, debug, modify schema, manage data|
+`pg_upgrade`|Upgrade PostgreSQL: version migration, compatibility, safety|
+`pipelines_create`|Creates new Heroku deployment pipeline with configurable stages, apps, and team settings|
+`pipelines_info`|Displays detailed pipeline configuration, stages, and connected applications|
+`pipelines_list`|Lists accessible Heroku pipelines with ownership and configuration details|
+`pipelines_promote`|Promotes apps between pipeline stages with configurable target applications|
+`ps_list`|List and monitor Heroku app dynos.|
+`ps_restart`|Restart Heroku app processes.|
+`ps_scale`|Scale Heroku app dynos.|
+`rename_app`|Rename app: validate and update app name|
+`transfer_app`|Transfer app ownership to user/team|
+
+---
+## Tools Details
+
+#### Tool: **`create_addon`**
+Create add-on: specify service, plan, custom names
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app for add-on. Must have write access. Region/space affects availability
+`serviceAndPlan`|`string`|Format: service_slug:plan_slug (e.g., heroku-postgresql:essential-0)
+`as`|`string` *optional*|Custom attachment name. Used for config vars prefix. Must be unique in app
+`name`|`string` *optional*|Global add-on identifier. Must be unique across all Heroku add-ons
+
+---
+#### Tool: **`create_app`**
+Create app: custom name, region (US/EU), team, private space
+Parameters|Type|Description
+-|-|-
+`app`|`string` *optional*|App name. Auto-generated if omitted
+`region`|`string` *optional*|Region: us/eu. Default: us. Excludes space param
+`space`|`string` *optional*|Private space name. Inherits region. Excludes region param
+`team`|`string` *optional*|Team name for ownership
+
+---
+#### Tool: **`deploy_one_off_dyno`**
+Run code/commands in Heroku one-off dyno with network and filesystem access.
+
+Requirements:
+- Show command output
+- Use app_info for buildpack detection
+- Support shell setup commands
+- Use stdout/stderr
+
+Features:
+- Network/filesystem access
+- Environment variables
+- File operations
+- Temp directory handling
+
+Usage:
+1. Use Heroku runtime
+2. Proper syntax/imports
+3. Organized code structure
+4. Package management:
+   - Define dependencies
+   - Minimize external deps
+   - Prefer native modules
+
+Example package.json:
+```json
+{
+  "type": "module",
+  "dependencies": {
+    "axios": "^1.6.0"
+  }
+}
+```
+Parameters|Type|Description
+-|-|-
+`command`|`string`|Command to run in dyno.
+`name`|`string`|Target Heroku app name.
+`env`|`object` *optional*|Dyno environment variables.
+`size`|`string` *optional*|Dyno size.
+`sources`|`array` *optional*|Source files to include in dyno.
+`timeToLive`|`number` *optional*|Dyno lifetime in seconds.
+
+---
+#### Tool: **`deploy_to_heroku`**
+Use for all deployments. Deploys new/existing apps, with or without teams/spaces, and env vars to Heroku. Ask for app name if missing. Requires valid app.json via appJson param.
+Parameters|Type|Description
+-|-|-
+`appJson`|`string`|App.json config for deployment. Must follow schema: {"default":{"$schema":"http://json-schema.org/draft-07/schema#","title":"Heroku app.json Schema","description":"app.json is a manifest format for describing web apps. It declares environment variables, add-ons, and other information required to run an app on Heroku. Used for dynamic configurations or converted projects","type":"object","properties":{"name":{"type":"string","pattern":"^[a-zA-Z-_\\.]+","maxLength":300},"description":{"type":"string"},"keywords":{"type":"array","items":{"type":"string"}},"website":{"$ref":"#/definitions/uriString"},"repository":{"$ref":"#/definitions/uriString"},"logo":{"$ref":"#/definitions/uriString"},"success_url":{"type":"string"},"scripts":{"$ref":"#/definitions/scripts"},"env":{"$ref":"#/definitions/env"},"formation":{"$ref":"#/definitions/formation"},"addons":{"$ref":"#/definitions/addons"},"buildpacks":{"$ref":"#/definitions/buildpacks"},"environments":{"$ref":"#/definitions/environments"},"stack":{"$ref":"#/definitions/stack"},"image":{"type":"string"}},"additionalProperties":false,"definitions":{"uriString":{"type":"string","format":"uri"},"scripts":{"type":"object","properties":{"postdeploy":{"type":"string"},"pr-predestroy":{"type":"string"}},"additionalProperties":false},"env":{"type":"object","patternProperties":{"^[A-Z][A-Z0-9_]*$":{"type":"object","properties":{"description":{"type":"string"},"value":{"type":"string"},"required":{"type":"boolean"},"generator":{"type":"string","enum":["secret"]}},"additionalProperties":false}}},"dynoSize":{"type":"string","enum":["free","eco","hobby","basic","standard-1x","standard-2x","performance-m","performance-l","private-s","private-m","private-l","shield-s","shield-m","shield-l"]},"formation":{"type":"object","patternProperties":{"^[a-zA-Z0-9_-]+$":{"type":"object","properties":{"quantity":{"type":"integer","minimum":0},"size":{"$ref":"#/definitions/dynoSize"}},"required":["quantity"],"additionalProperties":false}}},"addons":{"type":"array","items":{"oneOf":[{"type":"string"},{"type":"object","properties":{"plan":{"type":"string"},"as":{"type":"string"},"options":{"type":"object"}},"required":["plan"],"additionalProperties":false}]}},"buildpacks":{"type":"array","items":{"type":"object","properties":{"url":{"type":"string"}},"required":["url"],"additionalProperties":false}},"environmentConfig":{"type":"object","properties":{"env":{"type":"object"},"formation":{"type":"object"},"addons":{"type":"array"},"buildpacks":{"type":"array"}}},"environments":{"type":"object","properties":{"test":{"allOf":[{"$ref":"#/definitions/environmentConfig"},{"type":"object","properties":{"scripts":{"type":"object","properties":{"test":{"type":"string"}},"additionalProperties":false}}}]},"review":{"$ref":"#/definitions/environmentConfig"},"production":{"$ref":"#/definitions/environmentConfig"}},"additionalProperties":false},"stack":{"type":"string","enum":["heroku-18","heroku-20","heroku-22","heroku-24"]}}}}
+`name`|`string`|App name for deployment. Creates new app if not exists.
+`rootUri`|`string`|Workspace root directory path.
+`env`|`object` *optional*|Environment variables overriding app.json values
+`internalRouting`|`boolean` *optional*|Enable internal routing in private spaces.
+`spaceId`|`string` *optional*|Private space ID for space deployments.
+`tarballUri`|`string` *optional*|URL of deployment tarball. Creates from rootUri if not provided.
+`teamId`|`string` *optional*|Team ID for team deployments.
+
+---
+#### Tool: **`get_addon_info`**
+Get add-on details: plan, state, billing
+Parameters|Type|Description
+-|-|-
+`addon`|`string`|Add-on identifier: UUID, name (postgresql-curved-12345), or attachment name (DATABASE)
+`app`|`string` *optional*|App context for add-on lookup. Required for attachment names. Uses Git remote default
+
+---
+#### Tool: **`get_app_info`**
+Get app details: config, dynos, addons, access, domains
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name. Requires access permissions
+`json`|`boolean` *optional*|JSON output with full metadata. Default: text format
+
+---
+#### Tool: **`get_app_logs`**
+App logs: monitor/debug/filter by dyno/process/source
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Heroku app name. Requires: permissions, Cedar-gen
+`dynoName`|`string` *optional*|Format: web.1/worker.2. Excludes processType
+`processType`|`string` *optional*|web|worker. All instances. Excludes dynoName
+`source`|`string` *optional*|app=application, heroku=platform. Default: all
+
+---
+#### Tool: **`list_addon_plans`**
+List service plans: features, pricing, availability
+Parameters|Type|Description
+-|-|-
+`service`|`string`|Service slug (e.g., heroku-postgresql). Get from list_addon_services
+`json`|`boolean` *optional*|JSON output with pricing, features, space compatibility. Default: text format
+
+---
+#### Tool: **`list_addon_services`**
+List available add-on services and features
+Parameters|Type|Description
+-|-|-
+`json`|`boolean` *optional*|JSON output with sharing options and app generation support. Default: basic text
+
+---
+#### Tool: **`list_addons`**
+List add-ons: all apps or specific app, detailed metadata
+Parameters|Type|Description
+-|-|-
+`all`|`boolean` *optional*|List all add-ons across accessible apps. Overrides app param, shows full status
+`app`|`string` *optional*|Filter by app name. Shows add-ons and attachments. Uses Git remote default if omitted
+
+---
+#### Tool: **`list_apps`**
+List Heroku apps: owned, collaborator access, team/space filtering
+Parameters|Type|Description
+-|-|-
+`all`|`boolean` *optional*|Show owned apps and collaborator access. Default: owned only
+`personal`|`boolean` *optional*|List personal account apps only, ignoring default team
+`space`|`string` *optional*|Filter by private space name. Excludes team param
+`team`|`string` *optional*|Filter by team name. Excludes space param
+
+---
+#### Tool: **`list_private_spaces`**
+Lists Heroku Private Spaces with CIDR blocks, regions, compliance and capacity details. JSON output supported.
+Parameters|Type|Description
+-|-|-
+`json`|`boolean` *optional*|JSON output for detailed space metadata, text output if false/omitted
+
+---
+#### Tool: **`list_teams`**
+Lists accessible Heroku Teams. Use for: viewing teams, checking membership, getting team metadata, and verifying access. JSON output available.
+Parameters|Type|Description
+-|-|-
+`json`|`boolean` *optional*|Output format control - true for detailed JSON with team metadata, false/omitted for simplified text
+
+---
+#### Tool: **`maintenance_off`**
+Disable maintenance mode and restore normal app operations
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target Heroku app name
+
+---
+#### Tool: **`maintenance_on`**
+Enable maintenance mode and redirect traffic for a Heroku app
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target Heroku app name
+
+---
+#### Tool: **`pg_backups`**
+Manage backups: schedules, status, verification, recovery
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name
+
+---
+#### Tool: **`pg_credentials`**
+Manage access: credentials, permissions, security, monitoring
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name
+`database`|`string` *optional*|Database identifier. Format: APP_NAME::DB for other apps. Default: DATABASE_URL
+
+---
+#### Tool: **`pg_info`**
+View database status: config, metrics, resources, health
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name
+`database`|`string` *optional*|Database identifier. Format: APP_NAME::DB for other apps. Default: all databases
+
+---
+#### Tool: **`pg_kill`**
+Stop processes: stuck queries, blocking transactions, runaway operations
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name
+`pid`|`number`|Process ID to terminate
+`database`|`string` *optional*|Database identifier. Format: APP_NAME::DB for other apps. Default: DATABASE_URL
+`force`|`boolean` *optional*|Force immediate termination
+
+---
+#### Tool: **`pg_locks`**
+Analyze locks: blocked queries, deadlocks, concurrency
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name
+`database`|`string` *optional*|Database identifier. Format: APP_NAME::DB for other apps. Default: DATABASE_URL
+`truncate`|`boolean` *optional*|Truncate queries to 40 chars
+
+---
+#### Tool: **`pg_maintenance`**
+Track maintenance: windows, schedules, progress, planning
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name
+`database`|`string` *optional*|Database identifier. Format: APP_NAME::DB for other apps. Default: DATABASE_URL
+
+---
+#### Tool: **`pg_outliers`**
+Find resource-heavy queries: performance, patterns, optimization
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name
+`database`|`string` *optional*|Database identifier. Format: APP_NAME::DB for other apps. Default: DATABASE_URL
+`num`|`number` *optional*|Number of queries to show. Default: 10
+`reset`|`boolean` *optional*|Reset pg_stat_statements stats
+`truncate`|`boolean` *optional*|Truncate queries to 40 chars
+
+---
+#### Tool: **`pg_ps`**
+Monitor active queries: progress, resources, performance
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name
+`database`|`string` *optional*|Database identifier. Format: APP_NAME::DB for other apps. Default: DATABASE_URL
+`verbose`|`boolean` *optional*|Show query plan and memory usage
+
+---
+#### Tool: **`pg_psql`**
+Execute SQL queries: analyze, debug, modify schema, manage data
+Parameters|Type|Description
+-|-|-
+`app`|`string`|app to run command against
+`command`|`string` *optional*|SQL command. Single line. Ignored if file provided
+`credential`|`string` *optional*|credential to use
+`database`|`string` *optional*|Database identifier: config var, name, ID, alias. Format: APP_NAME::DB for other apps. Default: DATABASE_URL
+`file`|`string` *optional*|SQL file path. Ignored if command provided
+
+---
+#### Tool: **`pg_upgrade`**
+Upgrade PostgreSQL: version migration, compatibility, safety
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Target app name
+`confirm`|`string` *optional*|Confirmation for destructive operation
+`database`|`string` *optional*|Database identifier. Format: APP_NAME::DB for other apps. Default: DATABASE_URL
+`version`|`string` *optional*|PostgreSQL version target
+
+---
+#### Tool: **`pipelines_create`**
+Creates new Heroku deployment pipeline with configurable stages, apps, and team settings
+Parameters|Type|Description
+-|-|-
+`name`|`string`|Pipeline name
+`stage`|`string`|Initial pipeline stage
+`app`|`string` *optional*|App to add to pipeline
+`team`|`string` *optional*|Team owning the pipeline
+
+---
+#### Tool: **`pipelines_info`**
+Displays detailed pipeline configuration, stages, and connected applications
+Parameters|Type|Description
+-|-|-
+`pipeline`|`string`|Target pipeline name
+`json`|`boolean` *optional*|Enable JSON output
+
+---
+#### Tool: **`pipelines_list`**
+Lists accessible Heroku pipelines with ownership and configuration details
+Parameters|Type|Description
+-|-|-
+`json`|`boolean` *optional*|Enable JSON output
+
+---
+#### Tool: **`pipelines_promote`**
+Promotes apps between pipeline stages with configurable target applications
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Source app for promotion
+`to`|`string` *optional*|Target apps for promotion (comma-separated)
+
+---
+#### Tool: **`ps_list`**
+List and monitor Heroku app dynos. View running dynos, check status/health, monitor process states, verify configurations.
+Parameters|Type|Description
+-|-|-
+`app`|`string`|App name to list processes for
+`json`|`boolean` *optional*|Output process info in JSON format
+
+---
+#### Tool: **`ps_restart`**
+Restart Heroku app processes. Restart specific dynos, process types, or all dynos. Reset dyno states selectively.
+Parameters|Type|Description
+-|-|-
+`app`|`string`|App name to restart processes for
+`dyno-name`|`string` *optional*|Specific dyno to restart (e.g., web.1). Omit both options to restart all
+`process-type`|`string` *optional*|Dyno type to restart (e.g., web). Omit both options to restart all
+
+---
+#### Tool: **`ps_scale`**
+Scale Heroku app dynos. Adjust quantities, change sizes, view formation details, manage resources.
+Parameters|Type|Description
+-|-|-
+`app`|`string`|App name to scale
+`dyno`|`string` *optional*|Dyno type and quantity (e.g., web=3:Standard-2X, worker+1). Omit to show current formation
+
+---
+#### Tool: **`rename_app`**
+Rename app: validate and update app name
+Parameters|Type|Description
+-|-|-
+`app`|`string`|Current app name. Requires access
+`newName`|`string`|New unique app name
+
+---
+#### Tool: **`transfer_app`**
+Transfer app ownership to user/team
+Parameters|Type|Description
+-|-|-
+`app`|`string`|App to transfer. Requires owner/admin access
+`recipient`|`string`|Target user email or team name
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "heroku": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "HEROKU_API_KEY",
+        "mcp/heroku"
+      ],
+      "env": {
+        "HEROKU_API_KEY": "<YOUR_HEROKU_AUTH_TOKEN>"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/maestro-mcp-server.md
+++ b/docs/mcp/maestro-mcp-server.md
@@ -1,0 +1,382 @@
+# Maestro MCP Server MCP Server
+
+A Model Context Protocol (MCP) server exposing Bitcoin blockchain data through the Maestro API platform. Provides tools to explore blocks, transactions, addresses, inscriptions, runes, and other metaprotocol data.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/maestro-mcp-server](https://hub.docker.com/repository/docker/mcp/maestro-mcp-server)
+**Author**|[maestro-org](https://github.com/maestro-org)
+**Repository**|https://github.com/maestro-org/maestro-mcp-server
+**Dockerfile**|https://github.com/maestro-org/maestro-mcp-server/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/maestro-mcp-server)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/maestro-mcp-server --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|Apache License 2.0
+
+## Available Tools (35)
+Tools provided by this Server|Short Description
+-|-
+`get_address_activity`|List satoshi balance change activity for an address.|
+`get_address_balance`|Get current satoshi balance for an address (confirmed only).|
+`get_address_balance_historical`|Get historical satoshi balances per block, with USD valuation.|
+`get_address_brc20`|List BRC-20 balances for an address (total and available).|
+`get_address_brc20_transfer_inscriptions`|List unspent BRC-20 transfer inscriptions at an address.|
+`get_address_inscriptions`|List inscriptions currently controlled by an address.|
+`get_address_inscription_activity`|List inscription send/receive/self-transfer activity for an address.|
+`get_address_runes`|List Rune balances for an address (total and available).|
+`get_address_rune_activity`|List Rune balance increases/decreases/self-transfers for an address.|
+`get_address_rune_utxos`|List UTXOs at an address containing Runes.|
+`get_address_statistics`|Get address stats: tx counts, UTXOs, sat balance, runes/inscriptions flags.|
+`get_address_txs`|List transactions that spent/produced UTXOs for an address.|
+`get_address_utxos`|List UTXOs for an address; supports dust and metaprotocol filtering.|
+`get_mempool_address_balance`|Get address satoshi balance including mempool-aware estimates.|
+`get_mempool_address_runes`|Get mempool-aware Rune balances for an address.|
+`list_brc20_assets`|List BRC-20 tickers deployed on-chain.|
+`get_brc20_info`|Get BRC-20 metadata and current state.|
+`list_supported_dexs`|List supported DEX identifiers for market endpoints.|
+`get_dex_ohlc`|Get OHLCV candles for a DEX and symbol.|
+`get_btc_price_by_timestamp`|Get BTC-USD price at a given UTC timestamp.|
+`get_rune_price_by_timestamp`|Get Rune price (USD and sats) at a given UTC timestamp.|
+`rpc_chain_info`|Bitcoin node and chain status from Node RPC.|
+`rpc_mempool_info`|Current mempool size, usage, fee thresholds, RBF state.|
+`rpc_mempool_transactions`|List transaction IDs currently in the mempool.|
+`rpc_block_miner_info`|Get miner metadata for a given block.|
+`rpc_block_volume`|Get total transaction output volume (sats) for a block.|
+`event_healthcheck`|Event Manager healthcheck.|
+`event_list_logs`|List event logs produced by triggers.|
+`event_get_log`|Get a single event log by id.|
+`event_list_triggers`|List all triggers.|
+`event_create_trigger`|Create a new trigger for on-chain events.|
+`event_get_trigger`|Get a trigger by id.|
+`event_update_trigger`|Update an existing trigger by id.|
+`event_delete_trigger`|Delete a trigger by id.|
+`event_list_trigger_condition_options`|List condition picklist options for triggers.|
+
+---
+## Tools Details
+
+#### Tool: **`get_address_activity`**
+List satoshi balance change activity for an address.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+`order`|`string`|asc or desc.
+`count`|`integer`|Results per page.
+`from`|`integer`|Min block height.
+`to`|`integer`|Max block height.
+`cursor`|`string`|Pagination cursor.
+`activity_kind`|`string`|increase | decrease | self_transfer.
+`exclude_self_transfers`|`boolean`|Exclude self-transfers.
+
+---
+#### Tool: **`get_address_balance`**
+Get current satoshi balance for an address (confirmed only).
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+
+---
+#### Tool: **`get_address_balance_historical`**
+Get historical satoshi balances per block, with USD valuation.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+`order`|`string`|asc or desc.
+`count`|`integer`|Results per page.
+`from`|`integer`|Min height or timestamp.
+`to`|`integer`|Max height or timestamp.
+`cursor`|`string`|Pagination cursor.
+`height_params`|`boolean`|If true, from/to are heights; false means timestamps.
+
+---
+#### Tool: **`get_address_brc20`**
+List BRC-20 balances for an address (total and available).
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+
+---
+#### Tool: **`get_address_brc20_transfer_inscriptions`**
+List unspent BRC-20 transfer inscriptions at an address.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+`ticker`|`string`|Optional BRC-20 ticker filter.
+`count`|`integer`|Results per page.
+`order`|`string`|asc or desc.
+`cursor`|`string`|Pagination cursor.
+
+---
+#### Tool: **`get_address_inscriptions`**
+List inscriptions currently controlled by an address.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+`count`|`integer`|Results per page.
+`cursor`|`string`|Pagination cursor.
+
+---
+#### Tool: **`get_address_inscription_activity`**
+List inscription send/receive/self-transfer activity for an address.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+`order`|`string`|asc or desc.
+`count`|`integer`|Results per page.
+`from`|`integer`|Min block height.
+`to`|`integer`|Max block height.
+`cursor`|`string`|Pagination cursor.
+`inscription_id`|`string`|Filter by inscription id.
+`activity_kind`|`string`|send | receive | self_transfer.
+`exclude_self_transfers`|`boolean`|Exclude self-transfers.
+
+---
+#### Tool: **`get_address_runes`**
+List Rune balances for an address (total and available).
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+
+---
+#### Tool: **`get_address_rune_activity`**
+List Rune balance increases/decreases/self-transfers for an address.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+`order`|`string`|asc or desc.
+`count`|`integer`|Results per page.
+`from`|`integer`|Min block height.
+`to`|`integer`|Max block height.
+`cursor`|`string`|Pagination cursor.
+`rune`|`string`|Rune ID (e.g., 840000:28) or name.
+`activity_kind`|`string`|increased | decreased | self_transfer.
+`exclude_self_transfers`|`boolean`|Exclude self-transfers.
+
+---
+#### Tool: **`get_address_rune_utxos`**
+List UTXOs at an address containing Runes.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+`rune`|`string`|Rune ID or name filter.
+`order_by`|`string`|height | amount.
+`order`|`string`|asc or desc.
+`count`|`integer`|Results per page.
+`cursor`|`string`|Pagination cursor.
+`from`|`integer`|Min block height.
+`to`|`integer`|Max block height.
+
+---
+#### Tool: **`get_address_statistics`**
+Get address stats: tx counts, UTXOs, sat balance, runes/inscriptions flags.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+
+---
+#### Tool: **`get_address_txs`**
+List transactions that spent/produced UTXOs for an address.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+`count`|`integer`|Results per page.
+`confirmations`|`integer`|Minimum confirmations.
+`order`|`string`|asc or desc.
+`from`|`integer`|Min block height.
+`to`|`integer`|Max block height.
+`cursor`|`string`|Pagination cursor.
+
+---
+#### Tool: **`get_address_utxos`**
+List UTXOs for an address; supports dust and metaprotocol filtering.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+`filter_dust`|`boolean`|Exclude UTXOs < 100k sats.
+`filter_dust_threshold`|`integer`|Custom dust threshold (sats).
+`exclude_metaprotocols`|`boolean`|Exclude Rune/inscription UTXOs.
+`ignore_used_brc20`|`boolean`|Keep UTXOs with used BRC-20 if excluding metaprotocols.
+`count`|`integer`|Results per page.
+`order`|`string`|asc or desc.
+`from`|`integer`|Min block height.
+`to`|`integer`|Max block height.
+`cursor`|`string`|Pagination cursor.
+
+---
+#### Tool: **`get_mempool_address_balance`**
+Get address satoshi balance including mempool-aware estimates.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+
+---
+#### Tool: **`get_mempool_address_runes`**
+Get mempool-aware Rune balances for an address.
+Parameters|Type|Description
+-|-|-
+`address`|`string`|Bech32 or scriptPubKey (hex).
+
+---
+#### Tool: **`list_brc20_assets`**
+List BRC-20 tickers deployed on-chain.
+Parameters|Type|Description
+-|-|-
+`count`|`integer`|Results per page.
+`cursor`|`string`|Pagination cursor.
+
+---
+#### Tool: **`get_brc20_info`**
+Get BRC-20 metadata and current state.
+Parameters|Type|Description
+-|-|-
+`ticker`|`string`|BRC-20 ticker (e.g., ORDI).
+
+---
+#### Tool: **`list_supported_dexs`**
+List supported DEX identifiers for market endpoints.
+#### Tool: **`get_dex_ohlc`**
+Get OHLCV candles for a DEX and symbol.
+Parameters|Type|Description
+-|-|-
+`dex`|`string`|all | magiceden | dotswap.
+`symbol`|`string`|Trading pair, e.g., BTC-840000:28.
+`mempool`|`string`|included | excluded | only.
+`resolution`|`string`|1m,5m,15m,30m,1h,4h,1d,1w,1M.
+`from`|`integer`|Unix seconds start.
+`to`|`integer`|Unix seconds end.
+
+---
+#### Tool: **`get_btc_price_by_timestamp`**
+Get BTC-USD price at a given UTC timestamp.
+Parameters|Type|Description
+-|-|-
+`timestamp`|`integer`|Unix seconds.
+
+---
+#### Tool: **`get_rune_price_by_timestamp`**
+Get Rune price (USD and sats) at a given UTC timestamp.
+Parameters|Type|Description
+-|-|-
+`rune_id`|`string`|Rune ID in <block>:<tx_index>.
+`timestamp`|`integer`|Unix seconds.
+
+---
+#### Tool: **`rpc_chain_info`**
+Bitcoin node and chain status from Node RPC.
+#### Tool: **`rpc_mempool_info`**
+Current mempool size, usage, fee thresholds, RBF state.
+#### Tool: **`rpc_mempool_transactions`**
+List transaction IDs currently in the mempool.
+#### Tool: **`rpc_block_miner_info`**
+Get miner metadata for a given block.
+Parameters|Type|Description
+-|-|-
+`height_or_hash`|`string`|Block height or block hash.
+
+---
+#### Tool: **`rpc_block_volume`**
+Get total transaction output volume (sats) for a block.
+Parameters|Type|Description
+-|-|-
+`height_or_hash`|`string`|Block height or block hash.
+
+---
+#### Tool: **`event_healthcheck`**
+Event Manager healthcheck.
+#### Tool: **`event_list_logs`**
+List event logs produced by triggers.
+Parameters|Type|Description
+-|-|-
+`page`|`integer`|Page number (1+).
+`limit`|`integer`|Items per page (1–100).
+`trigger_id`|`string`|Filter by trigger id.
+`chain`|`string`|Filter by chain (bitcoin).
+`network`|`string`|Filter by network (mainnet/testnet).
+
+---
+#### Tool: **`event_get_log`**
+Get a single event log by id.
+Parameters|Type|Description
+-|-|-
+`id`|`string`|Event log id.
+
+---
+#### Tool: **`event_list_triggers`**
+List all triggers.
+#### Tool: **`event_create_trigger`**
+Create a new trigger for on-chain events.
+Parameters|Type|Description
+-|-|-
+`name`|`string`|Trigger name.
+`chain`|`string`|bitcoin.
+`network`|`string`|mainnet or testnet.
+`type`|`string`|transaction.
+`webhook_url`|`string`|Webhook endpoint (URL).
+`filters`|`array`|Filter objects per schema.
+`confirmations`|`integer`|Required confirmations.
+`status`|`string`|active or paused.
+
+---
+#### Tool: **`event_get_trigger`**
+Get a trigger by id.
+Parameters|Type|Description
+-|-|-
+`id`|`string`|Trigger id.
+
+---
+#### Tool: **`event_update_trigger`**
+Update an existing trigger by id.
+Parameters|Type|Description
+-|-|-
+`id`|`string`|Trigger id.
+`name`|`string`|Updated name.
+`chain`|`string`|bitcoin.
+`network`|`string`|mainnet or testnet.
+`type`|`string`|transaction.
+`webhook_url`|`string`|Webhook endpoint (URL).
+`filters`|`array`|Filter objects per schema.
+`confirmations`|`integer`|Required confirmations.
+`status`|`string`|active or paused.
+
+---
+#### Tool: **`event_delete_trigger`**
+Delete a trigger by id.
+Parameters|Type|Description
+-|-|-
+`id`|`string`|Trigger id.
+
+---
+#### Tool: **`event_list_trigger_condition_options`**
+List condition picklist options for triggers.
+Parameters|Type|Description
+-|-|-
+`trigger_type`|`string`|transaction.
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "maestro-mcp-server": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "API_KEY_API_KEY",
+        "mcp/maestro-mcp-server"
+      ],
+      "env": {
+        "API_KEY_API_KEY": "your-maestro-api-key"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/mcp-reddit.md
+++ b/docs/mcp/mcp-reddit.md
@@ -1,0 +1,113 @@
+# Mcp reddit MCP Server
+
+A comprehensive Model Context Protocol (MCP) server for Reddit integration. This server enables AI agents to interact with Reddit programmatically through a standardized interface.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/reddit-mcp](https://hub.docker.com/repository/docker/mcp/reddit-mcp)
+**Author**|[KrishnaRandad2023](https://github.com/KrishnaRandad2023)
+**Repository**|https://github.com/KrishnaRandad2023/mcp-reddit
+**Dockerfile**|https://github.com/KrishnaRandad2023/mcp-reddit/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/reddit-mcp)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/reddit-mcp --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (6)
+Tools provided by this Server|Short Description
+-|-
+`fetchPosts`|Fetch hot posts from a subreddit|
+`getComments`|Get comments for a specific Reddit post|
+`getSubredditInfo`|Get information about a subreddit|
+`postComment`|Post a comment on a Reddit post|
+`postToSubreddit`|Create a new post in a subreddit|
+`searchPosts`|Search for posts within a subreddit|
+
+---
+## Tools Details
+
+#### Tool: **`fetchPosts`**
+Fetch hot posts from a subreddit
+Parameters|Type|Description
+-|-|-
+`subreddit`|`string`|Name of the subreddit
+`limit`|`integer` *optional*|Number of posts to fetch (1-100)
+
+---
+#### Tool: **`getComments`**
+Get comments for a specific Reddit post
+Parameters|Type|Description
+-|-|-
+`post_id`|`string`|Reddit post ID (without 't3_' prefix)
+
+---
+#### Tool: **`getSubredditInfo`**
+Get information about a subreddit
+Parameters|Type|Description
+-|-|-
+`subreddit`|`string`|Name of the subreddit
+
+---
+#### Tool: **`postComment`**
+Post a comment on a Reddit post
+Parameters|Type|Description
+-|-|-
+`comment_text`|`string`|Comment text to post
+`post_id`|`string`|Reddit post ID (without 't3_' prefix)
+
+---
+#### Tool: **`postToSubreddit`**
+Create a new post in a subreddit
+Parameters|Type|Description
+-|-|-
+`subreddit`|`string`|Name of the subreddit
+`title`|`string`|Post title
+`content`|`string` *optional*|Post content (for text posts)
+`url`|`string` *optional*|URL (for link posts)
+
+---
+#### Tool: **`searchPosts`**
+Search for posts within a subreddit
+Parameters|Type|Description
+-|-|-
+`query`|`string`|Search query
+`subreddit`|`string`|Name of the subreddit
+`limit`|`integer` *optional*|Number of results to return (1-100)
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "mcp-reddit": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "USERNAME",
+        "-e",
+        "REDDIT_CLIENT_ID",
+        "-e",
+        "REDDIT_CLIENT_SECRET",
+        "-e",
+        "REDDIT_PASSWORD",
+        "mcp/reddit-mcp"
+      ],
+      "env": {
+        "USERNAME": "yourRedditUsername",
+        "REDDIT_CLIENT_ID": "<REDDIT_CLIENT_ID>",
+        "REDDIT_CLIENT_SECRET": "<REDDIT_CLIENT_SECRET>",
+        "REDDIT_PASSWORD": "<REDDIT_PASSWORD>"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/mongodb.md
+++ b/docs/mcp/mongodb.md
@@ -1,0 +1,284 @@
+# MongoDB MCP Server
+
+A Model Context Protocol server to connect to MongoDB databases and MongoDB Atlas Clusters.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/mongodb](https://hub.docker.com/repository/docker/mcp/mongodb)
+**Author**|[mongodb-js](https://github.com/mongodb-js)
+**Repository**|https://github.com/mongodb-js/mongodb-mcp-server
+**Dockerfile**|https://github.com/mongodb-js/mongodb-mcp-server/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/mongodb)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/mongodb --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|Apache License 2.0
+
+## Available Tools (21)
+Tools provided by this Server|Short Description
+-|-
+`aggregate`|aggregate|
+`collection-indexes`|collection-indexes|
+`collection-schema`|collection-schema|
+`collection-storage-size`|collection-storage-size|
+`connect`|connect|
+`count`|count|
+`create-collection`|create-collection|
+`create-index`|create-index|
+`db-stats`|db-stats|
+`delete-many`|delete-many|
+`drop-collection`|drop-collection|
+`drop-database`|drop-database|
+`explain`|explain|
+`export`|export|
+`find`|find|
+`insert-many`|insert-many|
+`list-collections`|list-collections|
+`list-databases`|list-databases|
+`mongodb-logs`|mongodb-logs|
+`rename-collection`|rename-collection|
+`update-many`|update-many|
+
+---
+## Tools Details
+
+#### Tool: **`aggregate`**
+Run an aggregation against a MongoDB collection
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`pipeline`|`array`|An array of aggregation stages to execute
+`responseBytesLimit`|`number` *optional*|The maximum number of bytes to return in the response. This value is capped by the server’s configured maxBytesPerQuery and cannot be exceeded. Note to LLM: If the entire aggregation result is required, use the "export" tool instead of increasing this limit.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`collection-indexes`**
+Describe the indexes for a collection
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`collection-schema`**
+Describe the schema for a collection
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`responseBytesLimit`|`number` *optional*|The maximum number of bytes to return in the response. This value is capped by the server’s configured maxBytesPerQuery and cannot be exceeded.
+`sampleSize`|`number` *optional*|Number of documents to sample for schema inference
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`collection-storage-size`**
+Gets the size of the collection
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`connect`**
+Connect to a MongoDB instance
+Parameters|Type|Description
+-|-|-
+`connectionString`|`string`|MongoDB connection string (in the mongodb:// or mongodb+srv:// format)
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`count`**
+Gets the number of documents in a MongoDB collection using db.collection.count() and query as an optional filter parameter
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`query`|`object` *optional*|A filter/query parameter. Allows users to filter the documents to count. Matches the syntax of the filter argument of db.collection.count().
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`create-collection`**
+Creates a new collection in a database. If the database doesn't exist, it will be created automatically.
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+
+---
+#### Tool: **`create-index`**
+Create an index for a collection
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`keys`|`object`|The index definition
+`name`|`string` *optional*|The name of the index
+
+---
+#### Tool: **`db-stats`**
+Returns statistics that reflect the use state of a single database
+Parameters|Type|Description
+-|-|-
+`database`|`string`|Database name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`delete-many`**
+Removes all documents that match the filter from a MongoDB collection
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`filter`|`object` *optional*|The query filter, specifying the deletion criteria. Matches the syntax of the filter argument of db.collection.deleteMany()
+
+*This tool may perform destructive updates.*
+
+---
+#### Tool: **`drop-collection`**
+Removes a collection or view from the database. The method also removes any indexes associated with the dropped collection.
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+
+*This tool may perform destructive updates.*
+
+---
+#### Tool: **`drop-database`**
+Removes the specified database, deleting the associated data files
+Parameters|Type|Description
+-|-|-
+`database`|`string`|Database name
+
+*This tool may perform destructive updates.*
+
+---
+#### Tool: **`explain`**
+Returns statistics describing the execution of the winning plan chosen by the query optimizer for the evaluated method
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`method`|`array`|The method and its arguments to run
+`verbosity`|`string` *optional*|The verbosity of the explain plan, defaults to queryPlanner. If the user wants to know how fast is a query in execution time, use executionStats. It supports all verbosities as defined in the MongoDB Driver.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`export`**
+Export a query or aggregation results in the specified EJSON format.
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`exportTarget`|`array`|The export target along with its arguments.
+`exportTitle`|`string`|A short description to uniquely identify the export.
+`jsonExportFormat`|`string` *optional*|The format to be used when exporting collection data as EJSON with default being relaxed.
+relaxed: A string format that emphasizes readability and interoperability at the expense of type preservation. That is, conversion from relaxed format to BSON can lose type information.
+canonical: A string format that emphasizes type preservation at the expense of readability and interoperability. That is, conversion from canonical to BSON will generally preserve type information except in certain specific cases.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`find`**
+Run a find query against a MongoDB collection
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`filter`|`object` *optional*|The query filter, matching the syntax of the query argument of db.collection.find()
+`limit`|`number` *optional*|The maximum number of documents to return
+`projection`|`object` *optional*|The projection, matching the syntax of the projection argument of db.collection.find()
+`responseBytesLimit`|`number` *optional*|The maximum number of bytes to return in the response. This value is capped by the server’s configured maxBytesPerQuery and cannot be exceeded. Note to LLM: If the entire query result is required, use the "export" tool instead of increasing this limit.
+`sort`|`object` *optional*|A document, describing the sort order, matching the syntax of the sort argument of cursor.sort(). The keys of the object are the fields to sort on, while the values are the sort directions (1 for ascending, -1 for descending).
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`insert-many`**
+Insert an array of documents into a MongoDB collection
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`documents`|`array`|The array of documents to insert, matching the syntax of the document argument of db.collection.insertMany()
+
+---
+#### Tool: **`list-collections`**
+List all collections for a given database
+Parameters|Type|Description
+-|-|-
+`database`|`string`|Database name
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list-databases`**
+List all databases for a MongoDB connection
+#### Tool: **`mongodb-logs`**
+Returns the most recent logged mongod events
+Parameters|Type|Description
+-|-|-
+`limit`|`integer` *optional*|The maximum number of log entries to return.
+`type`|`string` *optional*|The type of logs to return. Global returns all recent log entries, while startupWarnings returns only warnings and errors from when the process started.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`rename-collection`**
+Renames a collection in a MongoDB database
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`newName`|`string`|The new name for the collection
+`dropTarget`|`boolean` *optional*|If true, drops the target collection if it exists
+
+---
+#### Tool: **`update-many`**
+Updates all documents that match the specified filter for a collection
+Parameters|Type|Description
+-|-|-
+`collection`|`string`|Collection name
+`database`|`string`|Database name
+`update`|`object`|An update document describing the modifications to apply using update operator expressions
+`filter`|`object` *optional*|The selection criteria for the update, matching the syntax of the filter argument of db.collection.updateOne()
+`upsert`|`boolean` *optional*|Controls whether to insert a new document if no documents match the filter
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "mongodb": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "MDB_MCP_CONNECTION_STRING",
+        "mcp/mongodb"
+      ],
+      "env": {
+        "MDB_MCP_CONNECTION_STRING": "mongodb+srv://username:password@cluster.mongodb.net/myDatabase"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/neon.md
+++ b/docs/mcp/neon.md
@@ -1,0 +1,622 @@
+# Neon MCP Server
+
+MCP server for interacting with Neon Management API and databases.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/neon](https://hub.docker.com/repository/docker/mcp/neon)
+**Author**|[neondatabase-labs](https://github.com/neondatabase-labs)
+**Repository**|https://github.com/neondatabase-labs/mcp-server-neon
+**Dockerfile**|https://github.com/neondatabase-labs/mcp-server-neon/blob/dbfa184afd9fc677c0d6b007a62b33194e883821/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/neon)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/neon --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (19)
+Tools provided by this Server|Short Description
+-|-
+`__node_version`|Get the Node.js version used by the MCP server|
+`complete_database_migration`|Complete a database migration when the user confirms the migration is ready to be applied to the main branch.|
+`complete_query_tuning`|Complete a query tuning session by either applying the changes to the main branch or discarding them.|
+`create_branch`|Create a branch in a Neon project|
+`create_project`|Create a new Neon project.|
+`delete_branch`|Delete a branch from a Neon project|
+`delete_project`|Delete a Neon project|
+`describe_branch`|Get a tree view of all objects in a branch, including databases, schemas, tables, views, and functions|
+`describe_project`|Describes a Neon project|
+`describe_table_schema`|Describe the schema of a table in a Neon database|
+`explain_sql_statement`|Describe the PostgreSQL query execution plan for a query of SQL statement by running EXPLAIN (ANAYLZE...) in the database|
+`get_connection_string`|Get a PostgreSQL connection string for a Neon database with all parameters being optional|
+`get_database_tables`|Get all tables in a Neon database|
+`list_projects`|List all Neon projects in your account.|
+`prepare_database_migration`|<use_case> This tool performs database schema migrations by automatically generating and executing DDL statements.|
+`prepare_query_tuning`|<use_case> This tool helps developers improve PostgreSQL query performance for slow queries or DML statements by analyzing execution plans and suggesting optimizations.|
+`provision_neon_auth`|This tool provisions authentication for a Neon project.|
+`run_sql`|<use_case> Use this tool to execute a single SQL statement against a Neon database.|
+`run_sql_transaction`|<use_case> Use this tool to execute a SQL transaction against a Neon database, should be used for multiple SQL statements.|
+
+---
+## Tools Details
+
+#### Tool: **`__node_version`**
+Get the Node.js version used by the MCP server
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`complete_database_migration`**
+Complete a database migration when the user confirms the migration is ready to be applied to the main branch. This tool also lets the client know that the temporary branch created by the prepare_database_migration tool has been deleted.
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`complete_query_tuning`**
+Complete a query tuning session by either applying the changes to the main branch or discarding them. 
+    <important_notes>
+        BEFORE RUNNING THIS TOOL: test out the changes in the temporary branch first by running 
+        - 'run_sql' with the suggested DDL statements.
+        - 'explain_sql_statement' with the original query and the temporary branch.
+        This tool is the ONLY way to finally apply changes afterthe 'prepare_query_tuning' tool to the main branch.
+        You MUST NOT use 'prepare_database_migration' or other tools to apply query tuning changes.
+        You MUST pass the tuning_id obtained from the 'prepare_query_tuning' tool, NOT the temporary branch ID as tuning_id to this tool.
+        You MUSt pass the temporary branch ID used in the 'prepare_query_tuning' tool as TEMPORARY branchId to this tool.
+        The tool OPTIONALLY receives a second branch ID or name which can be used instead of the main branch to apply the changes.
+        This tool MUST be called after tool 'prepare_query_tuning' even when the user rejects the changes, to ensure proper cleanup of temporary branches.
+    </important_notes>    
+
+    This tool:
+    1. Applies suggested changes (like creating indexes) to the main branch (or specified branch) if approved
+    2. Handles cleanup of temporary branch
+    3. Must be called even when changes are rejected to ensure proper cleanup
+
+    Workflow:
+    1. After 'prepare_query_tuning' suggests changes
+    2. User reviews and approves/rejects changes
+    3. This tool is called to either:
+      - Apply approved changes to main branch and cleanup
+      - OR just cleanup if changes are rejected
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`create_branch`**
+Create a branch in a Neon project
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`create_project`**
+Create a new Neon project. If someone is trying to create a database, use this tool.
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`delete_branch`**
+Delete a branch from a Neon project
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`delete_project`**
+Delete a Neon project
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`describe_branch`**
+Get a tree view of all objects in a branch, including databases, schemas, tables, views, and functions
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`describe_project`**
+Describes a Neon project
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`describe_table_schema`**
+Describe the schema of a table in a Neon database
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`explain_sql_statement`**
+Describe the PostgreSQL query execution plan for a query of SQL statement by running EXPLAIN (ANAYLZE...) in the database
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`get_connection_string`**
+Get a PostgreSQL connection string for a Neon database with all parameters being optional
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`get_database_tables`**
+Get all tables in a Neon database
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`list_projects`**
+List all Neon projects in your account.
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`prepare_database_migration`**
+<use_case>
+    This tool performs database schema migrations by automatically generating and executing DDL statements.
+
+    Supported operations:
+    CREATE operations:
+    - Add new columns (e.g., "Add email column to users table")
+    - Create new tables (e.g., "Create posts table with title and content columns")
+    - Add constraints (e.g., "Add unique constraint on users.email")
+
+    ALTER operations:
+    - Modify column types (e.g., "Change posts.views to bigint")
+    - Rename columns (e.g., "Rename user_name to username in users table")
+    - Add/modify indexes (e.g., "Add index on posts.title")
+    - Add/modify foreign keys (e.g., "Add foreign key from posts.user_id to users.id")
+
+    DROP operations:
+    - Remove columns (e.g., "Drop temporary_field from users table")
+    - Drop tables (e.g., "Drop the old_logs table")
+    - Remove constraints (e.g., "Remove unique constraint from posts.slug")
+
+    The tool will:
+    1. Parse your natural language request
+    2. Generate appropriate SQL
+    3. Execute in a temporary branch for safety
+    4. Verify the changes before applying to main branch
+
+    Project ID and database name will be automatically extracted from your request.
+    If the database name is not provided, the default neondb or first available database is used.
+  </use_case>
+
+  <workflow>
+    1. Creates a temporary branch
+    2. Applies the migration SQL in that branch
+    3. Returns migration details for verification
+  </workflow>
+
+  <important_notes>
+    After executing this tool, you MUST:
+    1. Test the migration in the temporary branch using the 'run_sql' tool
+    2. Ask for confirmation before proceeding
+    3. Use 'complete_database_migration' tool to apply changes to main branch
+  </important_notes>
+
+  <example>
+    For a migration like:
+    ALTER TABLE users ADD COLUMN last_login TIMESTAMP;
+
+    You should test it with:
+    SELECT column_name, data_type 
+    FROM information_schema.columns 
+    WHERE table_name = 'users' AND column_name = 'last_login';
+
+    You can use 'run_sql' to test the migration in the temporary branch that this
+    tool creates.
+  </example>
+
+
+  <next_steps>
+  After executing this tool, you MUST follow these steps:
+    1. Use 'run_sql' to verify changes on temporary branch
+    2. Follow these instructions to respond to the client: 
+
+      <response_instructions>
+        <instructions>
+          Provide a brief confirmation of the requested change and ask for migration commit approval.
+
+          You MUST include ALL of the following fields in your response:
+          - Migration ID (this is required for commit and must be shown first)  
+          - Temporary Branch Name (always include exact branch name)
+          - Temporary Branch ID (always include exact ID)
+          - Migration Result (include brief success/failure status)
+
+          Even if some fields are missing from the tool's response, use placeholders like "not provided" rather than omitting fields.
+        </instructions>
+
+        <do_not_include>
+          IMPORTANT: Your response MUST NOT contain ANY technical implementation details such as:
+          - Data types (e.g., DO NOT mention if a column is boolean, varchar, timestamp, etc.)
+          - Column specifications or properties
+          - SQL syntax or statements
+          - Constraint definitions or rules
+          - Default values
+          - Index types
+          - Foreign key specifications
+
+          Keep the response focused ONLY on confirming the high-level change and requesting approval.
+
+          <example>
+            INCORRECT: "I've added a boolean is_published column to the posts table..."
+            CORRECT: "I've added the is_published column to the posts table..."
+          </example>
+        </do_not_include>
+
+        <example>
+          I've verified that [requested change] has been successfully applied to a temporary branch. Would you like to commit the migration [migration_id] to the main branch?
+
+          Migration Details:
+          - Migration ID (required for commit)
+          - Temporary Branch Name
+          - Temporary Branch ID
+          - Migration Result
+        </example>
+      </response_instructions>
+
+    3. If approved, use 'complete_database_migration' tool with the migration_id
+  </next_steps>
+
+  <error_handling>
+    On error, the tool will:
+    1. Automatically attempt ONE retry of the exact same operation
+    2. If the retry fails:
+      - Terminate execution
+      - Return error details
+      - DO NOT attempt any other tools or alternatives
+
+    Error response will include:
+    - Original error details
+    - Confirmation that retry was attempted
+    - Final error state
+
+    Important: After a failed retry, you must terminate the current flow completely. Do not attempt to use alternative tools or workarounds.
+  </error_handling>
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`prepare_query_tuning`**
+<use_case>
+    This tool helps developers improve PostgreSQL query performance for slow queries or DML statements by analyzing execution plans and suggesting optimizations.
+
+    The tool will:
+    1. Create a temporary branch for testing optimizations and remember the branch ID
+    2. Extract and analyze the current query execution plan
+    3. Extract all fully qualified table names (schema.table) referenced in the plan 
+    4. Gather detailed schema information for each referenced table using describe_table_schema
+    5. Suggest and implement improvements like:
+      - Adding or modifying indexes based on table schemas and query patterns
+      - Query structure modifications
+      - Identifying potential performance bottlenecks
+    6. Apply the changes to the temporary branch using run_sql
+    7. Compare performance before and after changes (but ONLY on the temporary branch passing branch ID to all tools)
+    8. Continue with next steps using complete_query_tuning tool (on main branch)
+
+    Project ID and database name will be automatically extracted from your request.
+    The temporary branch ID will be added when invoking other tools.
+    Default database is neondb if not specified.
+
+    IMPORTANT: This tool is part of the query tuning workflow. Any suggested changes (like creating indexes) must first be applied to the temporary branch using the 'run_sql' tool.
+    and then to the main branch using the 'complete_query_tuning' tool, NOT the 'prepare_database_migration' tool. 
+    To apply using the 'complete_query_tuning' tool, you must pass the tuning_id, NOT the temporary branch ID to it.
+  </use_case>
+
+  <workflow>
+    1. Creates a temporary branch
+    2. Analyzes current query performance and extracts table information
+    3. Implements and tests improvements (using tool run_sql for schema modifications and explain_sql_statement for performance analysis, but ONLY on the temporary branch created in step 1 passing the same branch ID to all tools)
+    4. Returns tuning details for verification
+  </workflow>
+
+  <important_notes>
+    After executing this tool, you MUST:
+    1. Review the suggested changes
+    2. Verify the performance improvements on temporary branch - by applying the changes with run_sql and running explain_sql_statement again)
+    3. Decide whether to keep or discard the changes
+    4. Use 'complete_query_tuning' tool to apply or discard changes to the main branch
+
+    DO NOT use 'prepare_database_migration' tool for applying query tuning changes.
+    Always use 'complete_query_tuning' to ensure changes are properly tracked and applied.
+
+    Note: 
+    - Some operations like creating indexes can take significant time on large tables
+    - Table statistics updates (ANALYZE) are NOT automatically performed as they can be long-running
+    - Table statistics maintenance should be handled by PostgreSQL auto-analyze or scheduled maintenance jobs
+    - If statistics are suspected to be stale, suggest running ANALYZE as a separate maintenance task
+  </important_notes>
+
+  <example>
+    For a query like:
+    SELECT o.*, c.name 
+    FROM orders o 
+    JOIN customers c ON c.id = o.customer_id 
+    WHERE o.status = 'pending' 
+    AND o.created_at > '2024-01-01';
+
+    The tool will:
+    1. Extract referenced tables: public.orders, public.customers
+    2. Gather schema information for both tables
+    3. Analyze the execution plan
+    4. Suggest improvements like:
+       - Creating a composite index on orders(status, created_at)
+       - Optimizing the join conditions
+    5. If confirmed, apply the suggested changes to the temporary branch using run_sql
+    6. Compare execution plans and performance before and after changes (but ONLY on the temporary branch passing branch ID to all tools)
+
+  </example>
+
+  <next_steps>
+  After executing this tool, you MUST follow these steps:
+    1. Review the execution plans and suggested changes
+    2. Follow these instructions to respond to the client: 
+
+      <response_instructions>
+        <instructions>
+          Provide a brief summary of the performance analysis and ask for approval to apply changes on the temporary branch.
+
+          You MUST include ALL of the following fields in your response:
+          - Tuning ID (this is required for completion)
+          - Temporary Branch Name
+          - Temporary Branch ID
+          - Original Query Cost
+          - Improved Query Cost
+          - Referenced Tables (list all tables found in the plan)
+          - Suggested Changes
+
+          Even if some fields are missing from the tool's response, use placeholders like "not provided" rather than omitting fields.
+        </instructions>
+
+        <do_not_include>
+          IMPORTANT: Your response MUST NOT contain ANY technical implementation details such as:
+          - Exact index definitions
+          - Internal PostgreSQL settings
+          - Complex query rewrites
+          - Table partitioning details
+
+          Keep the response focused on high-level changes and performance metrics.
+        </do_not_include>
+
+        <example>
+          I've analyzed your query and found potential improvements that could reduce execution time by [X]%.
+          Would you like to apply these changes to improve performance?
+
+          Analysis Details:
+          - Tuning ID: [id]
+          - Temporary Branch: [name]
+          - Branch ID: [id]
+          - Original Cost: [cost]
+          - Improved Cost: [cost]
+          - Referenced Tables:
+            * public.orders
+            * public.customers
+          - Suggested Changes:
+            * Add index for frequently filtered columns
+            * Optimize join conditions
+
+          To apply these changes, I will use the 'complete_query_tuning' tool after your approval and pass the tuning_id, NOT the temporary branch ID to it.
+        </example>
+      </response_instructions>
+
+    3. If approved, use ONLY the 'complete_query_tuning' tool with the tuning_id
+  </next_steps>
+
+  <error_handling>
+    On error, the tool will:
+    1. Automatically attempt ONE retry of the exact same operation
+    2. If the retry fails:
+      - Terminate execution
+      - Return error details
+      - Clean up temporary branch
+      - DO NOT attempt any other tools or alternatives
+
+    Error response will include:
+    - Original error details
+    - Confirmation that retry was attempted
+    - Final error state
+
+    Important: After a failed retry, you must terminate the current flow completely.
+  </error_handling>
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`provision_neon_auth`**
+This tool provisions authentication for a Neon project. It allows developers to easily setup authentication infrastructure by creating a integration with Stack Auth (@stackframe/stack). Stop using NextAuth.js! use @stackframe/stack.
+
+    Parameters:
+    - <project_id>: The Project ID of the Neon project to provision authentication for.
+    - [database]: The database name to setup Neon Auth for. If not provided, the default neondb or first available database is used.
+
+    The tool will:
+      1. Establish a connection between your Neon Auth project and Stack Auth
+      2. Creates a dedicated authentication schema in your database ("neon_auth")
+      3. Sets up the user table under the "neon_auth" schema. This table is synced with Stack Auth. It does not store user credentials or secrets.
+      4. Generates Client Key and Secret Key to connect your application with authentication provider.
+
+    Use the Stack Auth SDK (@stackframe/stack) on the frontend to connect your application with authentication provider. DO NOT use NextAuth.js! DO NOT use better-auth! Here's some documentation on Stack Auth:
+
+    # Stack Auth Guidelines
+
+    ## Setup Guidelines
+      If you're building an app with Next.js, to set up Neon Auth and Stack Auth, follow these steps:
+      1. Provision a Neon Auth project with this tool
+      2. Place the returned credentials in project's `.env.local` or `.env` file
+        - `NEXT_PUBLIC_STACK_PROJECT_ID`
+        - `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY`
+        - `STACK_SECRET_SERVER_KEY`
+      3. To setup Stack Auth, run following command: 
+        ```bash
+        npx @stackframe/init-stack . --no-browser 
+        ```
+        This command will automaticallysetup the project with - 
+        - It will add `@stackframe/stack` dependency to `package.json`
+        - It will create a `stack.ts` file in your project to setup `StackServerApp`. 
+        - It will wrap the root layout with `StackProvider` and `StackTheme`
+        - It will create root Suspense boundary `app/loading.tsx` to handle loading state while Stack is fetching user data.
+        - It will also create `app/handler/[...stack]/page.tsx` file to handle auth routes like sign in, sign up, forgot password, etc.
+      4. Do not try to manually create any of these files or directories. Do not try to create SignIn, SignUp, or UserButton components manually, instead use the ones provided by `@stackframe/stack`.
+
+
+    ## Components Guidelines
+      - Use pre-built components from `@stackframe/stack` like `<UserButton />`, `<SignIn />`, and `<SignUp />` to quickly set up auth UI.
+      - You can also compose smaller pieces like `<OAuthButtonGroup />`, `<MagicLinkSignIn />`, and `<CredentialSignIn />` for custom flows.
+      - Example:
+
+        ```tsx
+        import { SignIn } from '@stackframe/stack';
+        export default function Page() {
+          return <SignIn />;
+        }
+        ```
+
+    ## User Management Guidelines
+      - In Client Components, use the `useUser()` hook to retrieve the current user (it returns `null` when not signed in).
+      - Update user details using `user.update({...})` and sign out via `user.signOut()`.
+      - For pages that require a user, call `useUser({ or: "redirect" })` so unauthorized visitors are automatically redirected.
+
+    ## Client Component Guidelines
+      - Client Components rely on hooks like `useUser()` and `useStackApp()`.
+      - Example:
+
+        ```tsx
+        "use client";
+        import { useUser } from "@stackframe/stack";
+        export function MyComponent() {
+          const user = useUser();
+          return <div>{user ? `Hello, ${user.displayName}` : "Not logged in"}</div>;
+        }
+        ```
+
+    ## Server Component Guidelines
+      - For Server Components, use `stackServerApp.getUser()` from your `stack.ts` file.
+      - Example:
+
+        ```tsx
+        import { stackServerApp } from "@/stack";
+        export default async function ServerComponent() {
+          const user = await stackServerApp.getUser();
+          return <div>{user ? `Hello, ${user.displayName}` : "Not logged in"}</div>;
+        }
+        ```
+
+    ## Page Protection Guidelines
+      - Protect pages by:
+        - Using `useUser({ or: "redirect" })` in Client Components.
+        - Using `await stackServerApp.getUser({ or: "redirect" })` in Server Components.
+        - Implementing middleware that checks for a user and redirects to `/handler/sign-in` if not found.
+      - Example middleware:
+
+        ```tsx
+        export async function middleware(request: NextRequest) {
+          const user = await stackServerApp.getUser();
+          if (!user) {
+            return NextResponse.redirect(new URL('/handler/sign-in', request.url));
+          }
+          return NextResponse.next();
+        }
+        export const config = { matcher: '/protected/:path*' };
+        ```
+
+      ```
+      ## Examples
+      ### Example: custom-profile-page
+      #### Task
+      Create a custom profile page that:
+      - Displays the user's avatar, display name, and email.
+      - Provides options to sign out.
+      - Uses Stack Auth components and hooks.
+      #### Response
+      ##### File: app/profile/page.tsx
+      ###### Code
+      ```tsx
+      'use client';
+      import { useUser, useStackApp, UserButton } from '@stackframe/stack';
+      export default function ProfilePage() {
+        const user = useUser({ or: "redirect" });
+        const app = useStackApp();
+        return (
+          <div>
+            <UserButton />
+            <h1>Welcome, {user.displayName || "User"}</h1>
+            <p>Email: {user.primaryEmail}</p>
+            <button onClick={() => user.signOut()}>Sign Out</button>
+          </div>
+        );
+      }
+      ```
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`run_sql`**
+<use_case>
+      Use this tool to execute a single SQL statement against a Neon database.
+    </use_case>
+
+    <important_notes>
+      If you have a temporary branch from a prior step, you MUST:
+      1. Pass the branch ID to this tool unless explicitly told otherwise
+      2. Tell the user that you are using the temporary branch with ID [branch_id]
+    </important_notes>
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+#### Tool: **`run_sql_transaction`**
+<use_case>
+      Use this tool to execute a SQL transaction against a Neon database, should be used for multiple SQL statements.
+    </use_case>
+
+    <important_notes>
+      If you have a temporary branch from a prior step, you MUST:
+      1. Pass the branch ID to this tool unless explicitly told otherwise
+      2. Tell the user that you are using the temporary branch with ID [branch_id]
+    </important_notes>
+Parameters|Type|Description
+-|-|-
+`params`|`object`|
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "neon": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "NEON_API_KEY",
+        "mcp/neon"
+      ],
+      "env": {
+        "NEON_API_KEY": "YOUR_API_KEY_HERE"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/notion.md
+++ b/docs/mcp/notion.md
@@ -1,0 +1,235 @@
+# Notion MCP Server
+
+Official Notion MCP Server.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/notion](https://hub.docker.com/repository/docker/mcp/notion)
+**Author**|[makenotion](https://github.com/makenotion)
+**Repository**|https://github.com/makenotion/notion-mcp-server
+**Dockerfile**|https://github.com/makenotion/notion-mcp-server/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/notion)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/notion --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (19)
+Tools provided by this Server|Short Description
+-|-
+`API-create-a-comment`|Notion | Create comment|
+`API-create-a-database`|Notion | Create a database|
+`API-delete-a-block`|Notion | Delete a block|
+`API-get-block-children`|Notion | Retrieve block children|
+`API-get-self`|Notion | Retrieve your token's bot user|
+`API-get-user`|Notion | Retrieve a user|
+`API-get-users`|Notion | List all users|
+`API-patch-block-children`|Notion | Append block children|
+`API-patch-page`|Notion | Update page properties|
+`API-post-database-query`|Notion | Query a database|
+`API-post-page`|Notion | Create a page|
+`API-post-search`|Notion | Search by title|
+`API-retrieve-a-block`|Notion | Retrieve a block|
+`API-retrieve-a-comment`|Notion | Retrieve comments|
+`API-retrieve-a-database`|Notion | Retrieve a database|
+`API-retrieve-a-page`|Notion | Retrieve a page|
+`API-retrieve-a-page-property`|Notion | Retrieve a page property item|
+`API-update-a-block`|Notion | Update a block|
+`API-update-a-database`|Notion | Update a database|
+
+---
+## Tools Details
+
+#### Tool: **`API-create-a-comment`**
+Notion | Create comment
+Parameters|Type|Description
+-|-|-
+`parent`|`object`|The page that contains the comment
+`rich_text`|`array`|
+
+---
+#### Tool: **`API-create-a-database`**
+Notion | Create a database
+Parameters|Type|Description
+-|-|-
+`parent`|`object`|
+`properties`|`object`|Property schema of database. The keys are the names of properties as they appear in Notion and the values are [property schema objects](https://developers.notion.com/reference/property-schema-object).
+`title`|`array` *optional*|
+
+---
+#### Tool: **`API-delete-a-block`**
+Notion | Delete a block
+Parameters|Type|Description
+-|-|-
+`block_id`|`string`|Identifier for a Notion block
+
+---
+#### Tool: **`API-get-block-children`**
+Notion | Retrieve block children
+Parameters|Type|Description
+-|-|-
+`block_id`|`string`|Identifier for a [block](ref:block)
+`page_size`|`integer` *optional*|The number of items from the full list desired in the response. Maximum: 100
+`start_cursor`|`string` *optional*|If supplied, this endpoint will return a page of results starting after the cursor provided. If not supplied, this endpoint will return the first page of results.
+
+---
+#### Tool: **`API-get-self`**
+Notion | Retrieve your token's bot user
+#### Tool: **`API-get-user`**
+Notion | Retrieve a user
+Parameters|Type|Description
+-|-|-
+`user_id`|`string`|
+
+---
+#### Tool: **`API-get-users`**
+Notion | List all users
+Parameters|Type|Description
+-|-|-
+`page_size`|`integer` *optional*|The number of items from the full list desired in the response. Maximum: 100
+`start_cursor`|`string` *optional*|If supplied, this endpoint will return a page of results starting after the cursor provided. If not supplied, this endpoint will return the first page of results.
+
+---
+#### Tool: **`API-patch-block-children`**
+Notion | Append block children
+Parameters|Type|Description
+-|-|-
+`block_id`|`string`|Identifier for a [block](ref:block). Also accepts a [page](ref:page) ID.
+`children`|`array`|Child content to append to a container block as an array of [block objects](ref:block)
+`after`|`string` *optional*|The ID of the existing block that the new block should be appended after.
+
+---
+#### Tool: **`API-patch-page`**
+Notion | Update page properties
+Parameters|Type|Description
+-|-|-
+`page_id`|`string`|The identifier for the Notion page to be updated.
+`archived`|`boolean` *optional*|
+`cover`|`object` *optional*|A cover image for the page. Only [external file objects](https://developers.notion.com/reference/file-object) are supported.
+`icon`|`object` *optional*|A page icon for the page. Supported types are [external file object](https://developers.notion.com/reference/file-object) or [emoji object](https://developers.notion.com/reference/emoji-object).
+`in_trash`|`boolean` *optional*|Set to true to delete a block. Set to false to restore a block.
+`properties`|`object` *optional*|The property values to update for the page. The keys are the names or IDs of the property and the values are property values. If a page property ID is not included, then it is not changed.
+
+---
+#### Tool: **`API-post-database-query`**
+Notion | Query a database
+Parameters|Type|Description
+-|-|-
+`database_id`|`string`|Identifier for a Notion database.
+`archived`|`boolean` *optional*|
+`filter`|`object` *optional*|When supplied, limits which pages are returned based on the [filter conditions](ref:post-database-query-filter).
+`filter_properties`|`array` *optional*|A list of page property value IDs associated with the database. Use this param to limit the response to a specific page property value or values for pages that meet the `filter` criteria.
+`in_trash`|`boolean` *optional*|
+`page_size`|`integer` *optional*|The number of items from the full list desired in the response. Maximum: 100
+`sorts`|`array` *optional*|When supplied, orders the results based on the provided [sort criteria](ref:post-database-query-sort).
+`start_cursor`|`string` *optional*|When supplied, returns a page of results starting after the cursor provided. If not supplied, this endpoint will return the first page of results.
+
+---
+#### Tool: **`API-post-page`**
+Notion | Create a page
+Parameters|Type|Description
+-|-|-
+`parent`|`object`|
+`properties`|`object`|
+`children`|`array` *optional*|The content to be rendered on the new page, represented as an array of [block objects](https://developers.notion.com/reference/block).
+`cover`|`string` *optional*|The cover image of the new page, represented as a [file object](https://developers.notion.com/reference/file-object).
+`icon`|`string` *optional*|The icon of the new page. Either an [emoji object](https://developers.notion.com/reference/emoji-object) or an [external file object](https://developers.notion.com/reference/file-object)..
+
+---
+#### Tool: **`API-post-search`**
+Notion | Search by title
+Parameters|Type|Description
+-|-|-
+`filter`|`object` *optional*|A set of criteria, `value` and `property` keys, that limits the results to either only pages or only databases. Possible `value` values are `"page"` or `"database"`. The only supported `property` value is `"object"`.
+`page_size`|`integer` *optional*|The number of items from the full list to include in the response. Maximum: `100`.
+`query`|`string` *optional*|The text that the API compares page and database titles against.
+`sort`|`object` *optional*|A set of criteria, `direction` and `timestamp` keys, that orders the results. The **only** supported timestamp value is `"last_edited_time"`. Supported `direction` values are `"ascending"` and `"descending"`. If `sort` is not provided, then the most recently edited results are returned first.
+`start_cursor`|`string` *optional*|A `cursor` value returned in a previous response that If supplied, limits the response to results starting after the `cursor`. If not supplied, then the first page of results is returned. Refer to [pagination](https://developers.notion.com/reference/intro#pagination) for more details.
+
+---
+#### Tool: **`API-retrieve-a-block`**
+Notion | Retrieve a block
+Parameters|Type|Description
+-|-|-
+`block_id`|`string`|Identifier for a Notion block
+
+---
+#### Tool: **`API-retrieve-a-comment`**
+Notion | Retrieve comments
+Parameters|Type|Description
+-|-|-
+`block_id`|`string`|Identifier for a Notion block or page
+`page_size`|`integer` *optional*|The number of items from the full list desired in the response. Maximum: 100
+`start_cursor`|`string` *optional*|If supplied, this endpoint will return a page of results starting after the cursor provided. If not supplied, this endpoint will return the first page of results.
+
+---
+#### Tool: **`API-retrieve-a-database`**
+Notion | Retrieve a database
+Parameters|Type|Description
+-|-|-
+`database_id`|`string`|An identifier for the Notion database.
+
+---
+#### Tool: **`API-retrieve-a-page`**
+Notion | Retrieve a page
+Parameters|Type|Description
+-|-|-
+`page_id`|`string`|Identifier for a Notion page
+`filter_properties`|`string` *optional*|A list of page property value IDs associated with the page. Use this param to limit the response to a specific page property value or values. To retrieve multiple properties, specify each page property ID. For example: `?filter_properties=iAk8&filter_properties=b7dh`.
+
+---
+#### Tool: **`API-retrieve-a-page-property`**
+Notion | Retrieve a page property item
+Parameters|Type|Description
+-|-|-
+`page_id`|`string`|Identifier for a Notion page
+`property_id`|`string`|Identifier for a page [property](https://developers.notion.com/reference/page#all-property-values)
+`page_size`|`integer` *optional*|For paginated properties. The max number of property item objects on a page. The default size is 100
+`start_cursor`|`string` *optional*|For paginated properties.
+
+---
+#### Tool: **`API-update-a-block`**
+Notion | Update a block
+Parameters|Type|Description
+-|-|-
+`block_id`|`string`|Identifier for a Notion block
+`archived`|`boolean` *optional*|Set to true to archive (delete) a block. Set to false to un-archive (restore) a block.
+`type`|`object` *optional*|The [block object `type`](ref:block#block-object-keys) value with the properties to be updated. Currently only `text` (for supported block types) and `checked` (for `to_do` blocks) fields can be updated.
+
+---
+#### Tool: **`API-update-a-database`**
+Notion | Update a database
+Parameters|Type|Description
+-|-|-
+`database_id`|`string`|identifier for a Notion database
+`description`|`array` *optional*|An array of [rich text objects](https://developers.notion.com/reference/rich-text) that represents the description of the database that is displayed in the Notion UI. If omitted, then the database description remains unchanged.
+`properties`|`object` *optional*|Property schema of database. The keys are the names of properties as they appear in Notion and the values are [property schema objects](https://developers.notion.com/reference/property-schema-object).
+`title`|`array` *optional*|An array of [rich text objects](https://developers.notion.com/reference/rich-text) that represents the title of the database that is displayed in the Notion UI. If omitted, then the database title remains unchanged.
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "notion": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "INTERNAL_INTEGRATION_TOKEN",
+        "mcp/notion"
+      ],
+      "env": {
+        "INTERNAL_INTEGRATION_TOKEN": "ntn_****"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/puppeteer.md
+++ b/docs/mcp/puppeteer.md
@@ -1,0 +1,112 @@
+# Puppeteer (Archived) MCP Server
+
+Browser automation and web scraping using Puppeteer.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/puppeteer](https://hub.docker.com/repository/docker/mcp/puppeteer)
+**Author**|[modelcontextprotocol](https://github.com/modelcontextprotocol)
+**Repository**|https://github.com/modelcontextprotocol/servers
+**Dockerfile**|https://github.com/modelcontextprotocol/servers/blob/2025.4.24/src/puppeteer/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/puppeteer)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/puppeteer --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (7)
+Tools provided by this Server|Short Description
+-|-
+`puppeteer_click`|Click an element on the page|
+`puppeteer_evaluate`|Execute JavaScript in the browser console|
+`puppeteer_fill`|Fill out an input field|
+`puppeteer_hover`|Hover an element on the page|
+`puppeteer_navigate`|Navigate to a URL|
+`puppeteer_screenshot`|Take a screenshot of the current page or a specific element|
+`puppeteer_select`|Select an element on the page with Select tag|
+
+---
+## Tools Details
+
+#### Tool: **`puppeteer_click`**
+Click an element on the page
+Parameters|Type|Description
+-|-|-
+`selector`|`string`|CSS selector for element to click
+
+---
+#### Tool: **`puppeteer_evaluate`**
+Execute JavaScript in the browser console
+Parameters|Type|Description
+-|-|-
+`script`|`string`|JavaScript code to execute
+
+---
+#### Tool: **`puppeteer_fill`**
+Fill out an input field
+Parameters|Type|Description
+-|-|-
+`selector`|`string`|CSS selector for input field
+`value`|`string`|Value to fill
+
+---
+#### Tool: **`puppeteer_hover`**
+Hover an element on the page
+Parameters|Type|Description
+-|-|-
+`selector`|`string`|CSS selector for element to hover
+
+---
+#### Tool: **`puppeteer_navigate`**
+Navigate to a URL
+Parameters|Type|Description
+-|-|-
+`url`|`string`|URL to navigate to
+`allowDangerous`|`boolean` *optional*|Allow dangerous LaunchOptions that reduce security. When false, dangerous args like --no-sandbox will throw errors. Default false.
+`launchOptions`|`object` *optional*|PuppeteerJS LaunchOptions. Default null. If changed and not null, browser restarts. Example: { headless: true, args: ['--no-sandbox'] }
+
+---
+#### Tool: **`puppeteer_screenshot`**
+Take a screenshot of the current page or a specific element
+Parameters|Type|Description
+-|-|-
+`name`|`string`|Name for the screenshot
+`height`|`number` *optional*|Height in pixels (default: 600)
+`selector`|`string` *optional*|CSS selector for element to screenshot
+`width`|`number` *optional*|Width in pixels (default: 800)
+
+---
+#### Tool: **`puppeteer_select`**
+Select an element on the page with Select tag
+Parameters|Type|Description
+-|-|-
+`selector`|`string`|CSS selector for element to select
+`value`|`string`|Value to select
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "puppeteer": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "DOCKER_CONTAINER",
+        "mcp/puppeteer"
+      ],
+      "env": {
+        "DOCKER_CONTAINER": "true"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/rust-mcp-filesystem.md
+++ b/docs/mcp/rust-mcp-filesystem.md
@@ -1,0 +1,313 @@
+# Blazing-fast, asynchronous MCP server for seamless filesystem operations. MCP Server
+
+The Rust MCP Filesystem is a high-performance, asynchronous, and lightweight Model Context Protocol (MCP) server built in Rust for secure and efficient filesystem operations. Designed with security in mind, it operates in read-only mode by default and restricts clients from updating allowed directories via MCP Roots unless explicitly enabled, ensuring robust protection against unauthorized access. Leveraging asynchronous I/O, it delivers blazingly fast performance with a minimal resource footprint.
+Optimized for token efficiency, the Rust MCP Filesystem enables large language models (LLMs) to precisely target searches and edits within specific sections of large files and restrict operations by file size range, making it ideal for efficient file exploration, automation, and system integration.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/rust-mcp-filesystem](https://hub.docker.com/repository/docker/mcp/rust-mcp-filesystem)
+**Author**|[rust-mcp-stack](https://github.com/rust-mcp-stack)
+**Repository**|https://github.com/rust-mcp-stack/rust-mcp-filesystem
+**Dockerfile**|https://github.com/rust-mcp-stack/rust-mcp-filesystem/blob/main/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/rust-mcp-filesystem)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/rust-mcp-filesystem --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (24)
+Tools provided by this Server|Short Description
+-|-
+`calculate_directory_size`|Calculates the total size of a directory specified by `root_path`.It recursively searches for files and sums their sizes.|
+`create_directory`|Create a new directory or ensure a directory exists.|
+`directory_tree`|Get a recursive tree view of files and directories as a JSON structure.|
+`edit_file`|Make line-based edits to a text file.|
+`find_duplicate_files`|Find duplicate files within a directory and return list of duplicated files as text or json formatOptional `pattern` argument can be used to narrow down the file search to specific glob pattern.Optional `exclude_patterns` can be used to exclude certain files matching a glob.`min_bytes` and `max_bytes` are optional arguments that can be used to restrict the search to files with sizes within a specified range.The output_format argument specifies the format of the output and accepts either `text` or `json` (default: text).Only works within allowed directories.|
+`find_empty_directories`|Recursively finds all empty directories within the given root path.A directory is considered empty if it contains no files in itself or any of its subdirectories.Operating system metadata files `.DS_Store` (macOS) and `Thumbs.db` (Windows) will be ignored.The optional exclude_patterns argument accepts glob-style patterns to exclude specific paths from the search.Only works within allowed directories.|
+`get_file_info`|Retrieve detailed metadata about a file or directory.|
+`head_file`|Reads and returns the first N lines of a text file.This is useful for quickly previewing file contents without loading the entire file into memory.If the file has fewer than N lines, the entire file will be returned.Only works within allowed directories.|
+`head_file`|Reads and returns the last N lines of a text file.This is useful for quickly previewing file contents without loading the entire file into memory.If the file has fewer than N lines, the entire file will be returned.Only works within allowed directories.|
+`list_allowed_directories`|Returns a list of directories that the server has permission to access Subdirectories within these allowed directories are also accessible.|
+`list_directory`|Get a detailed listing of all files and directories in a specified path.|
+`list_directory_with_sizes`|Get a detailed listing of all files and directories in a specified path, including sizes.|
+`move_file`|Move or rename files and directories.|
+`read_file_lines`|Reads lines from a text file starting at a specified line offset (0-based) and continues for the specified number of lines if a limit is provided.This function skips the first 'offset' lines and then reads up to 'limit' lines if specified, or reads until the end of the file otherwise.It's useful for partial reads, pagination, or previewing sections of large text files.Only works within allowed directories.|
+`read_media_file`|Reads an image or audio file and returns its Base64-encoded content along with the corresponding MIME type.|
+`read_multiple_media_files`|Reads multiple image or audio files and returns their Base64-encoded contents along with corresponding MIME types.|
+`read_multiple_text_files`|Read the contents of multiple text files simultaneously as text.|
+`read_text_file`|Read the complete contents of a text file from the file system as text.|
+`search_files`|Recursively search for files and directories matching a pattern.|
+`search_files_content`|Searches for text or regex patterns in the content of files matching matching a GLOB pattern.Returns detailed matches with file path, line number, column number and a preview of matched text.By default, it performs a literal text search; if the 'is_regex' parameter is set to true, it performs a regular expression (regex) search instead.Optional 'min_bytes' and 'max_bytes' arguments can be used to filter files by size, ensuring that only files within the specified byte range are included in the search.|
+`unzip_file`|Extracts the contents of a ZIP archive to a specified target directory.|
+`write_file`|Create a new file or completely overwrite an existing file with new content.|
+`zip_directory`|Creates a ZIP archive by compressing a directory , including files and subdirectories matching a specified glob pattern.|
+`zip_files`|Creates a ZIP archive by compressing files.|
+
+---
+## Tools Details
+
+#### Tool: **`calculate_directory_size`**
+Calculates the total size of a directory specified by `root_path`.It recursively searches for files and sums their sizes. The result can be returned in either a `human-readable` format or as `bytes`, depending on the specified `output_format` argument.Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`root_path`|`string`|The root directory path to start the size calculation.
+`output_format`|`string` *optional*|Defines the output format, which can be either `human-readable` or `bytes`.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`create_directory`**
+Create a new directory or ensure a directory exists. Can create multiple nested directories in one operation. If the directory already exists, this operation will succeed silently. Perfect for setting up directory structures for projects or ensuring required paths exist. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The path where the directory will be created.
+
+---
+#### Tool: **`directory_tree`**
+Get a recursive tree view of files and directories as a JSON structure. Each entry includes 'name', 'type' (file/directory), and 'children' for directories. Files have no children array, while directories always have a children array (which may be empty). If the 'max_depth' parameter is provided, the traversal will be limited to the specified depth. As a result, the returned directory structure may be incomplete or provide a skewed representation of the full directory tree, since deeper-level files and subdirectories beyond the specified depth will be excluded. The output is formatted with 2-space indentation for readability. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The root path of the directory tree to generate.
+`max_depth`|`integer` *optional*|Limits the depth of directory traversal
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`edit_file`**
+Make line-based edits to a text file. Each edit replaces exact line sequences with new content. Returns a git-style diff showing the changes made. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`edits`|`array`|The list of edit operations to apply.
+`path`|`string`|The path of the file to edit.
+`dryRun`|`boolean` *optional*|Preview changes using git-style diff format without applying them.
+
+---
+#### Tool: **`find_duplicate_files`**
+Find duplicate files within a directory and return list of duplicated files as text or json formatOptional `pattern` argument can be used to narrow down the file search to specific glob pattern.Optional `exclude_patterns` can be used to exclude certain files matching a glob.`min_bytes` and `max_bytes` are optional arguments that can be used to restrict the search to files with sizes within a specified range.The output_format argument specifies the format of the output and accepts either `text` or `json` (default: text).Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`root_path`|`string`|The root directory path to start the search.
+`exclude_patterns`|`array` *optional*|Optional list of glob patterns to exclude from the search. File matching these patterns will be ignored.
+`max_bytes`|`integer` *optional*|Maximum file size (in bytes) to include in the search (optional).
+`min_bytes`|`integer` *optional*|Minimum file size (in bytes) to include in the search (default to 1).
+`output_format`|`string` *optional*|Specify the output format, accepts either `text` or `json` (default: text).
+`pattern`|`string` *optional*|Optional glob pattern can be used to match target files.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`find_empty_directories`**
+Recursively finds all empty directories within the given root path.A directory is considered empty if it contains no files in itself or any of its subdirectories.Operating system metadata files `.DS_Store` (macOS) and `Thumbs.db` (Windows) will be ignored.The optional exclude_patterns argument accepts glob-style patterns to exclude specific paths from the search.Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The path of the file to get information for.
+`exclude_patterns`|`array` *optional*|Optional list of glob patterns to exclude from the search. Directories matching these patterns will be ignored.
+`output_format`|`string` *optional*|Specify the output format, accepts either `text` or `json` (default: text).
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`get_file_info`**
+Retrieve detailed metadata about a file or directory. Returns comprehensive information including size, creation time, last modified time, permissions, and type. This tool is perfect for understanding file characteristics without reading the actual content. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The path of the file to get information for.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`head_file`**
+Reads and returns the first N lines of a text file.This is useful for quickly previewing file contents without loading the entire file into memory.If the file has fewer than N lines, the entire file will be returned.Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`lines`|`integer`|The number of lines to read from the beginning of the file.
+`path`|`string`|The path of the file to get information for.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`head_file`**
+Reads and returns the last N lines of a text file.This is useful for quickly previewing file contents without loading the entire file into memory.If the file has fewer than N lines, the entire file will be returned.Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`lines`|`integer`|The number of lines to read from the beginning of the file.
+`path`|`string`|The path of the file to get information for.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_allowed_directories`**
+Returns a list of directories that the server has permission to access Subdirectories within these allowed directories are also accessible. Use this to identify which directories and their nested paths are available before attempting to access files.
+#### Tool: **`list_directory`**
+Get a detailed listing of all files and directories in a specified path. Results clearly distinguish between files and directories with [FILE] and [DIR] prefixes. This tool is essential for understanding directory structure and finding specific files within a directory. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The path of the directory to list.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`list_directory_with_sizes`**
+Get a detailed listing of all files and directories in a specified path, including sizes. Results clearly distinguish between files and directories with [FILE] and [DIR] prefixes. This tool is useful for understanding directory structure and finding specific files within a directory. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The path of the directory to list.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`move_file`**
+Move or rename files and directories. Can move files between directories and rename them in a single operation. If the destination exists, the operation will fail. Works across different directories and can be used for simple renaming within the same directory. Both source and destination must be within allowed directories.
+Parameters|Type|Description
+-|-|-
+`destination`|`string`|The destination path to move the file to.
+`source`|`string`|The source path of the file to move.
+
+---
+#### Tool: **`read_file_lines`**
+Reads lines from a text file starting at a specified line offset (0-based) and continues for the specified number of lines if a limit is provided.This function skips the first 'offset' lines and then reads up to 'limit' lines if specified, or reads until the end of the file otherwise.It's useful for partial reads, pagination, or previewing sections of large text files.Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`offset`|`integer`|Number of lines to skip from the start (0-based).
+`path`|`string`|The path of the file to get information for.
+`limit`|`integer` *optional*|Optional maximum number of lines to read after the offset.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`read_media_file`**
+Reads an image or audio file and returns its Base64-encoded content along with the corresponding MIME type. The max_bytes argument could be used to enforce an upper limit on the size of a file to read if the media file exceeds this limit, the operation will return an error instead of reading the media file. Access is restricted to files within allowed directories only.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The path of the file to read.
+`max_bytes`|`integer` *optional*|Maximum allowed file size (in bytes) to be read.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`read_multiple_media_files`**
+Reads multiple image or audio files and returns their Base64-encoded contents along with corresponding MIME types. This method is more efficient than reading files individually. The max_bytes argument could be used to enforce an upper limit on the size of a file to read Failed reads for specific files are skipped without interrupting the entire operation. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`paths`|`array`|The list of media file paths to read.
+`max_bytes`|`integer` *optional*|Maximum allowed file size (in bytes) to be read.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`read_multiple_text_files`**
+Read the contents of multiple text files simultaneously as text. This is more efficient than reading files one by one when you need to analyze or compare multiple files. Each file's content is returned with its path as a reference. Failed reads for individual files won't stop the entire operation. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`paths`|`array`|The list of file paths to read.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`read_text_file`**
+Read the complete contents of a text file from the file system as text. Handles various text encodings and provides detailed error messages if the file cannot be read. Use this tool when you need to examine the contents of a single file. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The path of the file to read.
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`search_files`**
+Recursively search for files and directories matching a pattern. Searches through all subdirectories from the starting path. The search is case-insensitive and matches partial names. Returns full paths to all matching items.Optional 'min_bytes' and 'max_bytes' arguments can be used to filter files by size, ensuring that only files within the specified byte range are included in the search. This tool is great for finding files when you don't know their exact location or find files by their size.Only searches within allowed directories.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The directory path to search in.
+`pattern`|`string`|Glob pattern used to match target files (e.g., "*.rs").
+`excludePatterns`|`array` *optional*|Optional list of patterns to exclude from the search.
+`max_bytes`|`integer` *optional*|Maximum file size (in bytes) to include in the search (optional).
+`min_bytes`|`integer` *optional*|Minimum file size (in bytes) to include in the search (optional).
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`search_files_content`**
+Searches for text or regex patterns in the content of files matching matching a GLOB pattern.Returns detailed matches with file path, line number, column number and a preview of matched text.By default, it performs a literal text search; if the 'is_regex' parameter is set to true, it performs a regular expression (regex) search instead.Optional 'min_bytes' and 'max_bytes' arguments can be used to filter files by size, ensuring that only files within the specified byte range are included in the search. Ideal for finding specific code, comments, or text when you don’t know their exact location.
+Parameters|Type|Description
+-|-|-
+`path`|`string`|The file or directory path to search in.
+`pattern`|`string`|The file glob pattern to match (e.g., "*.rs").
+`query`|`string`|Text or regex pattern to find in file contents (e.g., 'TODO' or '^function\\s+').
+`excludePatterns`|`array` *optional*|Optional list of patterns to exclude from the search.
+`is_regex`|`boolean` *optional*|Whether the query is a regular expression. If false, the query as plain text. (Default : false)
+`max_bytes`|`integer` *optional*|Maximum file size (in bytes) to include in the search (optional).
+`min_bytes`|`integer` *optional*|Minimum file size (in bytes) to include in the search (optional).
+
+*This tool is read-only. It does not modify its environment.*
+
+---
+#### Tool: **`unzip_file`**
+Extracts the contents of a ZIP archive to a specified target directory.
+It takes a source ZIP file path and a target extraction directory.
+The tool decompresses all files and directories stored in the ZIP, recreating their structure in the target location.
+Both the source ZIP file and the target directory should reside within allowed directories.
+Parameters|Type|Description
+-|-|-
+`target_path`|`string`|Path to the target directory where the contents of the ZIP file will be extracted.
+`zip_file`|`string`|A filesystem path to an existing ZIP file to be extracted.
+
+---
+#### Tool: **`write_file`**
+Create a new file or completely overwrite an existing file with new content. Use with caution as it will overwrite existing files without warning. Handles text content with proper encoding. Only works within allowed directories.
+Parameters|Type|Description
+-|-|-
+`content`|`string`|The content to write to the file.
+`path`|`string`|The path of the file to write to.
+
+---
+#### Tool: **`zip_directory`**
+Creates a ZIP archive by compressing a directory , including files and subdirectories matching a specified glob pattern.
+It takes a path to the folder and a glob pattern to identify files to compress and a target path for the resulting ZIP file.
+Both the source directory and the target ZIP file should reside within allowed directories.
+Parameters|Type|Description
+-|-|-
+`input_directory`|`string`|Path to the directory to zip
+`target_zip_file`|`string`|Path to save the resulting ZIP file, including filename and .zip extension
+`pattern`|`string` *optional*|A optional glob pattern to match files and subdirectories to zip, defaults to **/*"
+
+---
+#### Tool: **`zip_files`**
+Creates a ZIP archive by compressing files. It takes a list of files to compress and a target path for the resulting ZIP file. Both the source files and the target ZIP file should reside within allowed directories.
+Parameters|Type|Description
+-|-|-
+`input_files`|`array`|The list of files to include in the ZIP archive.
+`target_zip_file`|`string`|Path to save the resulting ZIP file, including filename and .zip extension
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "rust-mcp-filesystem": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "ENABLE_ROOTS",
+        "-e",
+        "ALLOW_WRITE",
+        "-v",
+        "/local-directory:/local-directory",
+        "mcp/rust-mcp-filesystem",
+        "{{rust-mcp-filesystem.allowed_directories|volume-target|into}}"
+      ],
+      "env": {
+        "ENABLE_ROOTS": "false",
+        "ALLOW_WRITE": "false"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/simplechecklist.md
+++ b/docs/mcp/simplechecklist.md
@@ -1,0 +1,232 @@
+# SimpleCheckList MCP Server MCP Server
+
+Advanced SimpleCheckList with MCP server and SQLite database for comprehensive task management.
+
+Features:
+• Complete project and task management system
+• Hierarchical organization (Projects → Groups → Task Lists → Tasks → Subtasks)
+• SQLite database for data persistence
+• RESTful API with comprehensive endpoints
+• MCP protocol compliance for AI assistant integration
+• Docker-optimized deployment with stability improvements
+
+**v1.0.1 Update**: Enhanced Docker stability with improved container lifecycle management.
+Default mode optimized for containerized deployment with reliable startup and shutdown processes.
+
+Perfect for AI assistants managing complex project workflows and task hierarchies.
+.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mayurkakade/mcp-server:latest](https://hub.docker.com/repository/docker/mayurkakade/mcp-server:latest)
+**Author**|[DevMayur](https://github.com/DevMayur)
+**Repository**|https://github.com/DevMayur/SimpleCheckList
+**Dockerfile**|https://github.com/DevMayur/SimpleCheckList/blob/main/Dockerfile
+**Docker Image built by**|DevMayur
+**Docker Scout Health Score**|Not available
+**Verify Signature**|Not available
+**Licence**|
+
+## Available Tools (20)
+Tools provided by this Server|Short Description
+-|-
+`list_projects`|Get all projects from SimpleCheckList|
+`create_project`|Create a new project|
+`get_project`|Get a specific project by ID|
+`update_project`|Update a project|
+`delete_project`|Delete a project|
+`list_groups`|Get all groups for a project|
+`create_group`|Create a new group in a project|
+`list_task_lists`|Get all task lists for a group|
+`create_task_list`|Create a new task list in a group|
+`list_tasks`|Get all tasks for a task list|
+`create_task`|Create a new task in a task list|
+`toggle_task_completion`|Toggle task completion status|
+`update_task`|Update a task|
+`delete_task`|Delete a task|
+`list_subtasks`|Get all subtasks for a task|
+`create_subtask`|Create a new subtask|
+`toggle_subtask_completion`|Toggle subtask completion status|
+`delete_subtask`|Delete a subtask|
+`get_project_stats`|Get statistics for a project|
+`get_all_tasks`|Get all tasks with full details across all projects|
+
+---
+## Tools Details
+
+#### Tool: **`list_projects`**
+Get all projects from SimpleCheckList
+#### Tool: **`create_project`**
+Create a new project
+Parameters|Type|Description
+-|-|-
+`name`|`string`|Project name
+`description`|`string`|Project description
+`color`|`string`|Project color (hex code)
+
+---
+#### Tool: **`get_project`**
+Get a specific project by ID
+Parameters|Type|Description
+-|-|-
+`project_id`|`string`|Project ID
+
+---
+#### Tool: **`update_project`**
+Update a project
+Parameters|Type|Description
+-|-|-
+`project_id`|`string`|Project ID
+`name`|`string`|New project name
+`description`|`string`|New project description
+`color`|`string`|New project color
+
+---
+#### Tool: **`delete_project`**
+Delete a project
+Parameters|Type|Description
+-|-|-
+`project_id`|`string`|Project ID
+
+---
+#### Tool: **`list_groups`**
+Get all groups for a project
+Parameters|Type|Description
+-|-|-
+`project_id`|`string`|Project ID
+
+---
+#### Tool: **`create_group`**
+Create a new group in a project
+Parameters|Type|Description
+-|-|-
+`project_id`|`string`|Project ID
+`name`|`string`|Group name
+`description`|`string`|Group description
+`order_index`|`number`|Order index for sorting
+
+---
+#### Tool: **`list_task_lists`**
+Get all task lists for a group
+Parameters|Type|Description
+-|-|-
+`group_id`|`string`|Group ID
+
+---
+#### Tool: **`create_task_list`**
+Create a new task list in a group
+Parameters|Type|Description
+-|-|-
+`group_id`|`string`|Group ID
+`name`|`string`|Task list name
+`description`|`string`|Task list description
+`order_index`|`number`|Order index for sorting
+
+---
+#### Tool: **`list_tasks`**
+Get all tasks for a task list
+Parameters|Type|Description
+-|-|-
+`task_list_id`|`string`|Task list ID
+
+---
+#### Tool: **`create_task`**
+Create a new task in a task list
+Parameters|Type|Description
+-|-|-
+`task_list_id`|`string`|Task list ID
+`title`|`string`|Task title
+`description`|`string`|Task description
+`priority`|`string`|Task priority (low, medium, high)
+`due_date`|`string`|Due date (ISO string)
+`metadata`|`object`|Additional task metadata
+
+---
+#### Tool: **`toggle_task_completion`**
+Toggle task completion status
+Parameters|Type|Description
+-|-|-
+`task_id`|`string`|Task ID
+
+---
+#### Tool: **`update_task`**
+Update a task
+Parameters|Type|Description
+-|-|-
+`task_id`|`string`|Task ID
+`title`|`string`|New task title
+`description`|`string`|New task description
+`priority`|`string`|New task priority
+`due_date`|`string`|New due date (ISO string)
+`metadata`|`object`|New task metadata
+
+---
+#### Tool: **`delete_task`**
+Delete a task
+Parameters|Type|Description
+-|-|-
+`task_id`|`string`|Task ID
+
+---
+#### Tool: **`list_subtasks`**
+Get all subtasks for a task
+Parameters|Type|Description
+-|-|-
+`task_id`|`string`|Task ID
+
+---
+#### Tool: **`create_subtask`**
+Create a new subtask
+Parameters|Type|Description
+-|-|-
+`task_id`|`string`|Task ID
+`title`|`string`|Subtask title
+`order_index`|`number`|Order index for sorting
+
+---
+#### Tool: **`toggle_subtask_completion`**
+Toggle subtask completion status
+Parameters|Type|Description
+-|-|-
+`subtask_id`|`string`|Subtask ID
+
+---
+#### Tool: **`delete_subtask`**
+Delete a subtask
+Parameters|Type|Description
+-|-|-
+`subtask_id`|`string`|Subtask ID
+
+---
+#### Tool: **`get_project_stats`**
+Get statistics for a project
+Parameters|Type|Description
+-|-|-
+`project_id`|`string`|Project ID
+
+---
+#### Tool: **`get_all_tasks`**
+Get all tasks with full details across all projects
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "simplechecklist": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "mayurkakade/mcp-server:latest",
+        "--mode=backend"
+      ]
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/mcp/stripe.md
+++ b/docs/mcp/stripe.md
@@ -1,0 +1,423 @@
+# Stripe MCP Server
+
+Interact with Stripe services over the Stripe API.
+
+[What is an MCP Server?](https://www.anthropic.com/news/model-context-protocol)
+
+## Characteristics
+Attribute|Details|
+|-|-|
+**Docker Image**|[mcp/stripe](https://hub.docker.com/repository/docker/mcp/stripe)
+**Author**|[stripe](https://github.com/stripe)
+**Repository**|https://github.com/stripe/agent-toolkit
+**Dockerfile**|https://github.com/stripe/agent-toolkit/blob/main/modelcontextprotocol/Dockerfile
+**Docker Image built by**|Docker Inc.
+**Docker Scout Health Score**| ![Docker Scout Health Score](https://api.scout.docker.com/v1/policy/insights/org-image-score/badge/mcp/stripe)
+**Verify Signature**|`COSIGN_REPOSITORY=mcp/signatures cosign verify mcp/stripe --key https://raw.githubusercontent.com/docker/keyring/refs/heads/main/public/mcp/latest.pub`
+**Licence**|MIT License
+
+## Available Tools (22)
+Tools provided by this Server|Short Description
+-|-
+`cancel_subscription`|Cancel subscription|
+`create_coupon`|Create coupon|
+`create_customer`|Create customer|
+`create_invoice`|Create invoice|
+`create_invoice_item`|Create invoice item|
+`create_payment_link`|Create payment link|
+`create_price`|Create price|
+`create_product`|Create product|
+`create_refund`|Create refund|
+`finalize_invoice`|Finalize invoice|
+`list_coupons`|List coupons|
+`list_customers`|List customers|
+`list_disputes`|List disputes|
+`list_invoices`|List invoices|
+`list_payment_intents`|List payment intents|
+`list_prices`|List prices|
+`list_products`|List products|
+`list_subscriptions`|List subscriptions|
+`retrieve_balance`|Retrieve balance|
+`search_stripe_documentation`|Search Stripe documentation|
+`update_dispute`|Update dispute|
+`update_subscription`|Update subscription|
+
+---
+## Tools Details
+
+#### Tool: **`cancel_subscription`**
+This tool will cancel a subscription in Stripe.
+
+It takes the following arguments:
+- subscription (str, required): The ID of the subscription to cancel.
+Parameters|Type|Description
+-|-|-
+`subscription`|`string`|The ID of the subscription to cancel.
+
+*This tool may perform destructive updates.*
+
+*This tool is idempotent. Repeated calls with same args have no additional effect.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`create_coupon`**
+This tool will create a coupon in Stripe.
+
+
+It takes several arguments:
+- name (str): The name of the coupon.
+
+Only use one of percent_off or amount_off, not both:
+- percent_off (number, optional): The percentage discount to apply (between 0 and 100).
+- amount_off (number, optional): The amount to subtract from an invoice (in cents).
+
+Optional arguments for duration. Use if specific duration is desired, otherwise default to 'once'.
+- duration (str, optional): How long the discount will last ('once', 'repeating', or 'forever'). Defaults to 'once'.
+- duration_in_months (number, optional): The number of months the discount will last if duration is repeating.
+Parameters|Type|Description
+-|-|-
+`amount_off`|`number`|A positive integer representing the amount to subtract from an invoice total (required if percent_off is not passed)
+`name`|`string`|Name of the coupon displayed to customers on invoices or receipts
+`currency`|`string` *optional*|Three-letter ISO code for the currency of the amount_off parameter (required if amount_off is passed). Infer based on the amount_off. For example, if a coupon is $2 off, set currency to be USD.
+`duration`|`string` *optional*|How long the discount will last. Defaults to "once"
+`duration_in_months`|`number` *optional*|The number of months the discount will last if duration is repeating
+`percent_off`|`number` *optional*|A positive float larger than 0, and smaller or equal to 100, that represents the discount the coupon will apply (required if amount_off is not passed)
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`create_customer`**
+This tool will create a customer in Stripe.
+
+It takes two arguments:
+- name (str): The name of the customer.
+- email (str, optional): The email of the customer.
+Parameters|Type|Description
+-|-|-
+`name`|`string`|The name of the customer
+`email`|`string` *optional*|The email of the customer
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`create_invoice`**
+This tool will create an invoice in Stripe.
+
+  It takes two arguments:
+  - customer (str): The ID of the customer to create the invoice for.
+
+  - days_until_due (int, optional): The number of days until the invoice is due.
+Parameters|Type|Description
+-|-|-
+`customer`|`string`|The ID of the customer to create the invoice for.
+`days_until_due`|`integer` *optional*|The number of days until the invoice is due.
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`create_invoice_item`**
+This tool will create an invoice item in Stripe.
+
+It takes three arguments'}:
+- customer (str): The ID of the customer to create the invoice item for.
+
+- price (str): The ID of the price to create the invoice item for.
+- invoice (str): The ID of the invoice to create the invoice item for.
+Parameters|Type|Description
+-|-|-
+`customer`|`string`|The ID of the customer to create the invoice item for.
+`invoice`|`string`|The ID of the invoice to create the item for.
+`price`|`string`|The ID of the price for the item.
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`create_payment_link`**
+This tool will create a payment link in Stripe.
+
+It takes two arguments:
+- price (str): The ID of the price to create the payment link for.
+- quantity (int): The quantity of the product to include in the payment link.
+- redirect_url (str, optional): The URL to redirect to after the payment is completed.
+Parameters|Type|Description
+-|-|-
+`price`|`string`|The ID of the price to create the payment link for.
+`quantity`|`integer`|The quantity of the product to include.
+`redirect_url`|`string` *optional*|The URL to redirect to after the payment is completed.
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`create_price`**
+This tool will create a price in Stripe. If a product has not already been specified, a product should be created first.
+
+It takes three arguments:
+- product (str): The ID of the product to create the price for.
+- unit_amount (int): The unit amount of the price in cents.
+- currency (str): The currency of the price.
+Parameters|Type|Description
+-|-|-
+`currency`|`string`|The currency of the price.
+`product`|`string`|The ID of the product to create the price for.
+`unit_amount`|`integer`|The unit amount of the price in cents.
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`create_product`**
+This tool will create a product in Stripe.
+
+It takes two arguments:
+- name (str): The name of the product.
+- description (str, optional): The description of the product.
+Parameters|Type|Description
+-|-|-
+`name`|`string`|The name of the product.
+`description`|`string` *optional*|The description of the product.
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`create_refund`**
+This tool will refund a payment intent in Stripe.
+
+It takes three arguments:
+- payment_intent (str): The ID of the payment intent to refund.
+- amount (int, optional): The amount to refund in cents.
+- reason (str, optional): The reason for the refund.
+Parameters|Type|Description
+-|-|-
+`payment_intent`|`string`|The ID of the PaymentIntent to refund.
+`amount`|`integer` *optional*|The amount to refund in cents.
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`finalize_invoice`**
+This tool will finalize an invoice in Stripe.
+
+It takes one argument:
+- invoice (str): The ID of the invoice to finalize.
+Parameters|Type|Description
+-|-|-
+`invoice`|`string`|The ID of the invoice to finalize.
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`list_coupons`**
+This tool will fetch a list of Coupons from Stripe.
+
+It takes one optional argument:
+- limit (int, optional): The number of coupons to return.
+Parameters|Type|Description
+-|-|-
+`limit`|`integer` *optional*|A limit on the number of objects to be returned. Limit can range between 1 and 100.
+
+*This tool is read-only. It does not modify its environment.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`list_customers`**
+This tool will fetch a list of Customers from Stripe.
+
+It takes two arguments:
+- limit (int, optional): The number of customers to return.
+- email (str, optional): A case-sensitive filter on the list based on the customer's email field.
+Parameters|Type|Description
+-|-|-
+`email`|`string` *optional*|A case-sensitive filter on the list based on the customer's email field. The value must be a string.
+`limit`|`integer` *optional*|A limit on the number of objects to be returned. Limit can range between 1 and 100.
+
+*This tool is read-only. It does not modify its environment.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`list_disputes`**
+This tool will fetch a list of disputes in Stripe.
+
+It takes the following arguments:
+- charge (string, optional): Only return disputes associated to the charge specified by this charge ID.
+- payment_intent (string, optional): Only return disputes associated to the PaymentIntent specified by this PaymentIntent ID.
+Parameters|Type|Description
+-|-|-
+`charge`|`string` *optional*|Only return disputes associated to the charge specified by this charge ID.
+`limit`|`integer` *optional*|A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+`payment_intent`|`string` *optional*|Only return disputes associated to the PaymentIntent specified by this PaymentIntent ID.
+
+*This tool is read-only. It does not modify its environment.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`list_invoices`**
+This tool will fetch a list of Invoices from Stripe.
+
+It takes two arguments:
+- customer (str, optional): The ID of the customer to list invoices for.
+
+- limit (int, optional): The number of invoices to return.
+Parameters|Type|Description
+-|-|-
+`customer`|`string` *optional*|The ID of the customer to list invoices for.
+`limit`|`integer` *optional*|A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+
+*This tool is read-only. It does not modify its environment.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`list_payment_intents`**
+This tool will list payment intents in Stripe.
+
+It takes two arguments:
+- customer (str, optional): The ID of the customer to list payment intents for.
+
+- limit (int, optional): The number of payment intents to return.
+Parameters|Type|Description
+-|-|-
+`customer`|`string` *optional*|The ID of the customer to list payment intents for.
+`limit`|`integer` *optional*|A limit on the number of objects to be returned. Limit can range between 1 and 100.
+
+*This tool is read-only. It does not modify its environment.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`list_prices`**
+This tool will fetch a list of Prices from Stripe.
+
+It takes two arguments.
+- product (str, optional): The ID of the product to list prices for.
+- limit (int, optional): The number of prices to return.
+Parameters|Type|Description
+-|-|-
+`limit`|`integer` *optional*|A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+`product`|`string` *optional*|The ID of the product to list prices for.
+
+*This tool is read-only. It does not modify its environment.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`list_products`**
+This tool will fetch a list of Products from Stripe.
+
+It takes one optional argument:
+- limit (int, optional): The number of products to return.
+Parameters|Type|Description
+-|-|-
+`limit`|`integer` *optional*|A limit on the number of objects to be returned. Limit can range between 1 and 100, and the default is 10.
+
+*This tool is read-only. It does not modify its environment.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`list_subscriptions`**
+This tool will list all subscriptions in Stripe.
+
+It takes four arguments:
+- customer (str, optional): The ID of the customer to list subscriptions for.
+
+- price (str, optional): The ID of the price to list subscriptions for.
+- status (str, optional): The status of the subscriptions to list.
+- limit (int, optional): The number of subscriptions to return.
+Parameters|Type|Description
+-|-|-
+`customer`|`string` *optional*|The ID of the customer to list subscriptions for.
+`limit`|`integer` *optional*|A limit on the number of objects to be returned. Limit can range between 1 and 100.
+`price`|`string` *optional*|The ID of the price to list subscriptions for.
+`status`|`string` *optional*|The status of the subscriptions to retrieve.
+
+*This tool is read-only. It does not modify its environment.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`retrieve_balance`**
+This tool will retrieve the balance from Stripe. It takes no input.
+#### Tool: **`search_stripe_documentation`**
+This tool will take in a user question about integrating with Stripe in their application, then search and retrieve relevant Stripe documentation to answer the question.
+
+It takes two arguments:
+- question (str): The user question to search an answer for in the Stripe documentation.
+- language (str, optional): The programming language to search for in the the documentation.
+Parameters|Type|Description
+-|-|-
+`question`|`string`|The user question about integrating with Stripe will be used to search the documentation.
+`language`|`string` *optional*|The programming language to search for in the the documentation.
+
+*This tool is read-only. It does not modify its environment.*
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`update_dispute`**
+When you receive a dispute, contacting your customer is always the best first step. If that doesn't work, you can submit evidence to help resolve the dispute in your favor. This tool helps.
+
+It takes the following arguments:
+- dispute (string): The ID of the dispute to update
+- evidence (object, optional): Evidence to upload for the dispute.
+    - cancellation_policy_disclosure (string)
+    - cancellation_rebuttal (string)
+    - duplicate_charge_explanation (string)
+    - uncategorized_text (string, optional): Any additional evidence or statements.
+- submit (boolean, optional): Whether to immediately submit evidence to the bank. If false, evidence is staged on the dispute.
+Parameters|Type|Description
+-|-|-
+`dispute`|`string`|The ID of the dispute to update
+`evidence`|`object` *optional*|Evidence to upload, to respond to a dispute. Updating any field in the hash will submit all fields in the hash for review.
+`submit`|`boolean` *optional*|Whether to immediately submit evidence to the bank. If false, evidence is staged on the dispute.
+
+*This tool interacts with external entities.*
+
+---
+#### Tool: **`update_subscription`**
+This tool will update an existing subscription in Stripe. If changing an existing subscription item, the existing subscription item has to be set to deleted and the new one has to be added.
+
+  It takes the following arguments:
+  - subscription (str, required): The ID of the subscription to update.
+  - proration_behavior (str, optional): Determines how to handle prorations when the subscription items change. Options: 'create_prorations', 'none', 'always_invoice', 'none_implicit'.
+  - items (array, optional): A list of subscription items to update, add, or remove. Each item can have the following properties:
+    - id (str, optional): The ID of the subscription item to modify.
+    - price (str, optional): The ID of the price to switch to.
+    - quantity (int, optional): The quantity of the plan to subscribe to.
+    - deleted (bool, optional): Whether to delete this item.
+Parameters|Type|Description
+-|-|-
+`subscription`|`string`|The ID of the subscription to update.
+`items`|`array` *optional*|A list of subscription items to update, add, or remove.
+`proration_behavior`|`string` *optional*|Determines how to handle prorations when the subscription items change.
+
+*This tool interacts with external entities.*
+
+---
+## Use this MCP Server
+
+```json
+{
+  "mcpServers": {
+    "stripe": {
+      "command": "docker",
+      "args": [
+        "run",
+        "-i",
+        "--rm",
+        "-e",
+        "STRIPE_SECRET_KEY",
+        "mcp/stripe",
+        "--tools=all"
+      ],
+      "env": {
+        "STRIPE_SECRET_KEY": "sk_STRIPE_SECRET_KEY"
+      }
+    }
+  }
+}
+```
+
+[Why is it safer to run MCP Servers with Docker?](https://www.docker.com/blog/the-model-context-protocol-simplifying-building-ai-apps-with-anthropic-claude-desktop-and-docker/)

--- a/docs/repo-capabilities.md
+++ b/docs/repo-capabilities.md
@@ -1,0 +1,35 @@
+# Repository Capability Overview
+
+This document summarizes the main systems bundled in the codex meta repository so that new operators can quickly understand the surfaces exposed to Cursor/Codex agents and human contributors.
+
+## Core Applications and Modules
+
+- **U-DIG-IT Hub**
+  - `backend/`: FastAPI application that wires CORS, Sentry, database bootstrapping, and router registration in `main.py`. 【F:docs/CONTEXT_INDEX.md†L7-L13】【F:docs/architecture.md†L1-L6】
+  - `frontend/`: Vite + React UI scaffold for the rental platform backed by pnpm tooling. 【F:docs/CONTEXT_INDEX.md†L7-L13】
+  - `docs/`: Hub-specific architecture notes used when the product expands. 【F:docs/CONTEXT_INDEX.md†L7-L13】
+- **OpenAI Tooling Submodules** – bundled as Git submodules that expose the latest SDKs and agent frameworks. 【F:docs/CONTEXT_INDEX.md†L15-L23】
+  - `core/openai-agents-python`: Python SDK for building multi-agent orchestrations, guardrails, and session state management. 【F:docs/CONTEXT_INDEX.md†L15-L18】
+  - `core/openai-agents-js`: JavaScript/TypeScript SDK with realtime extensions for browser and Node runtimes. 【F:docs/CONTEXT_INDEX.md†L15-L19】
+  - `sdk/openai-python` and `sdk/openai-node`: Official REST clients that power backend and frontend integrations. 【F:docs/CONTEXT_INDEX.md†L15-L21】
+  - `realtime/` and `voice/` directories: Canonical references for realtime, voice, and Whisper-based experiences. 【F:docs/CONTEXT_INDEX.md†L19-L22】
+- **Support Utilities** – docker images, token counters, and sample apps that accelerate prototyping. 【F:docs/CONTEXT_INDEX.md†L24-L30】
+
+## Development Workflow Highlights
+
+- Clone the repository with submodules, install backend/frontend dependencies, and copy `.env` templates before starting local development. 【F:docs/DEVELOPMENT.md†L6-L35】
+- Run `make dev` (or individual backend/frontend commands) to launch hot-reload servers. 【F:docs/DEVELOPMENT.md†L31-L38】
+- Enforce quality through language-specific tooling:
+  - Backend: Black formatting, isort, flake8, mypy, bandit, and safety checks. 【F:docs/DEVELOPMENT.md†L40-L59】
+  - Frontend: Prettier formatting, ESLint, strict TypeScript, and Vitest suites. 【F:docs/DEVELOPMENT.md†L59-L66】
+- Pre-commit hooks automatically run secret scanning, linting, security checks, and unit tests to maintain hygiene. 【F:docs/DEVELOPMENT.md†L68-L80】
+- Testing playbooks detail backend pytest targets, frontend Vitest commands, and security scanning make targets. 【F:docs/DEVELOPMENT.md†L82-L143】
+- Architecture guidance emphasizes modular FastAPI routers, Pydantic schemas, reusable React components/hooks, and async performance best practices. 【F:docs/DEVELOPMENT.md†L102-L151】
+
+## Automation and Tooling Touchpoints
+
+- The root `Makefile` collects frequently used workflows such as `make install`, `make backend-dev`, `make frontend-dev`, `make agents-test`, and composite smoke/test targets. 【F:Makefile†L1-L52】
+- CI guidance in `docs/integration-guides.md` explains how the GitHub workflow orchestrates backend compile checks, frontend builds, and agents SDK tests. 【F:docs/integration-guides.md†L29-L37】
+- Observability hooks rely on backend and frontend Sentry smoke tests plus guardrail documentation maintained alongside the Agents SDKs. 【F:docs/integration-guides.md†L21-L28】
+
+Refer back to this overview when onboarding new capabilities or when you need to trace where a subsystem originates inside the repository.


### PR DESCRIPTION
## Summary
- add a repository capability overview so agents can locate major modules and workflows quickly
- mirror the Docker MCP catalog readmes locally and generate an overview that summarizes 24 servers and their tool counts

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68d84cfd5fe08321a821397668e28cfe